### PR TITLE
Allow config system customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Looking to add a kick-ass repl to your config? Create and import something along
       # Supported systems, used for packages, apps, devShell and multiple other definitions. Defaults to `flake-utils.lib.defaultSystems`
       supportedSystems = [ "aarch64-linux" "x86_64-linux" ];
 
-      # Default architecture to be used for `nixosHosts` defaults to "x86_64-linux"
+      # Default architecture to be used for `hosts` defaults to "x86_64-linux"
       defaultSystem = "aarch64-linux";
 
       # Channel definitions. `channels.<name>.{input,overlaysBuilder,config,patches}`
@@ -80,7 +80,7 @@ Looking to add a kick-ass repl to your config? Create and import something along
       channelsConfig.allowUnfree = true;
 
       # Profiles, gets parsed into `nixosConfigurations`
-      nixosHosts = {
+      hosts = {
         # Profile name / System hostname
         FirstHost = {
           # System architecture. Defaults to `defaultSystem` argument
@@ -102,7 +102,7 @@ Looking to add a kick-ass repl to your config? Create and import something along
       # Shared overlays between channels, gets applied to all `channels.<name>.input`
       sharedOverlays = [ ];
 
-      # Shared modules/configurations between `nixosHosts`
+      # Shared modules/configurations between `hosts`
       sharedModules = [ utils.nixosModules.saneFlakeDefaults ];
 
 

--- a/examples/fully-featured-flake.nix
+++ b/examples/fully-featured-flake.nix
@@ -32,9 +32,9 @@
 
       # Default host settings.
       hostDefaults = {
-        # Default architecture to be used for `nixosHosts` defaults to "x86_64-linux"
+        # Default architecture to be used for `hosts` defaults to "x86_64-linux"
         system = "aarch64-linux";
-        # Default channel to be used for `nixosHosts` defaults to "nixpkgs"
+        # Default channel to be used for `hosts` defaults to "nixpkgs"
         channelName = "unstable";
         # Extra arguments to be passed to modules. Merged with sharedExtraArgs on its left hand side and the host's extraArgs on its right hand side
         extraArgs = { foo = "foo"; };
@@ -45,7 +45,7 @@
       # Extra arguments to be passed to modules. Defaults to `{ inherit inputs; }`
       sharedExtraArgs = { inherit utils inputs; };
 
-      # Shared modules/configurations between `nixosHosts`
+      # Shared modules/configurations between `hosts`
       sharedModules = [
         home-manager.nixosModules.home-manager
         # Sets sane `nix.*` defaults. Please refer to implementation/readme for more details.
@@ -101,7 +101,7 @@
       };
 
       # Profiles, gets parsed into `nixosConfigurations`
-      nixosHosts = {
+      hosts = {
         # Profile name / System hostname
         Morty = {
           # System architecture. Defaults to `defaultSystem` argument

--- a/examples/somewhat-realistic-flake.nix
+++ b/examples/somewhat-realistic-flake.nix
@@ -6,6 +6,7 @@
     unstable.url = github:nixos/nixpkgs/nixos-unstable;
     utils.url = github:gytis-ivaskevicius/flake-utils-plus;
 
+    nix-darwin.url = github:LnL7/nix-darwin;
     home-manager = {
       url = github:nix-community/home-manager/master;
       inputs.nixpkgs.follows = "nixpkgs";
@@ -13,7 +14,7 @@
   };
 
 
-  outputs = inputs@{ self, nixpkgs, unstable, utils, home-manager }:
+  outputs = inputs@{ self, nixpkgs, unstable, utils, nix-darwin, home-manager }:
     utils.lib.systemFlake {
 
       # `self` and `inputs` arguments are REQUIRED!!!!!!!!!!!!!!
@@ -56,6 +57,21 @@
         ];
       };
 
+      hosts."HostNameThree" = {
+        # This host will be exported under the flake's `darwinConfigurations` output
+        output = "darwinConfigurations";
+
+        # Build host with darwinSystem
+        builder = nix-darwin.lib.darwinSystem;
+
+        # This host uses `channels.unstable.{input,overlaysBuilder,config,patches}` attributes instead of `channels.nixpkgs.<...>`
+        channelName = "unstable";
+
+        # Host specific configuration. Same as `sharedModules`
+        modules = [
+          (import ./configurations/Morty.home.nix)
+        ];
+      };
 
 
 

--- a/examples/somewhat-realistic-flake.nix
+++ b/examples/somewhat-realistic-flake.nix
@@ -41,12 +41,12 @@
 
 
       # Profiles, gets parsed into `nixosConfigurations`
-      nixosHosts.HostnameOne.modules = [
+      hosts.HostnameOne.modules = [
         (import ./HostnameOneConfiguration.nix)
       ];
 
 
-      nixosHosts.HostnameTwo = {
+      hosts.HostnameTwo = {
         # This host uses `channels.unstable.{input,overlaysBuilder,config,patches}` attributes instead of `channels.nixpkgs.<...>`
         channelName = "unstable";
 
@@ -73,7 +73,7 @@
 
 
 
-      # Shared modules/configurations between `nixosHosts`
+      # Shared modules/configurations between `hosts`
       defaultHostsAttrs = {
         modules = [
           home-manager.nixosModules.home-manager

--- a/examples/somewhat-realistic-flake.nix
+++ b/examples/somewhat-realistic-flake.nix
@@ -67,7 +67,7 @@
         # This host uses `channels.unstable.{input,overlaysBuilder,config,patches}` attributes instead of `channels.nixpkgs.<...>`
         channelName = "unstable";
 
-        # Host specific configuration. Same as `sharedModules`
+        # Host specific configuration.
         modules = [
           (import ./configurations/Morty.home.nix)
         ];
@@ -90,7 +90,7 @@
 
 
       # Shared modules/configurations between `hosts`
-      defaultHostsAttrs = {
+      hostDefaults = {
         modules = [
           home-manager.nixosModules.home-manager
           # Sets sane `nix.*` defaults. Please refer to implementation/readme for more details.
@@ -107,7 +107,6 @@
 
     };
 }
-
 
 
 

--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -5,15 +5,16 @@
 , supportedSystems ? flake-utils-plus.lib.defaultSystems
 , inputs
 
-, nixosConfigurations ? { }
-, sharedExtraArgs ? { }
-, hostDefaults ? { }
-, nixosProfiles ? { } # will be deprecated soon, use nixosHosts, instead.
-, nixosHosts ? nixosProfiles
 , channels ? { }
 , channelsConfig ? { }
-, sharedModules ? [ ]
 , sharedOverlays ? [ ]
+
+, nixosConfigurations ? { } # deprecate soon, no longer used or works
+, hostDefaults ? { }
+, nixosProfiles ? { } # will be deprecated soon, use hosts, instead.
+, hosts ? nixosProfiles
+, sharedExtraArgs ? { }
+, sharedModules ? [ ]
 
 , packagesBuilder ? null
 , defaultPackageBuilder ? null

--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -29,28 +29,42 @@ let
   inherit (flake-utils-plus.lib) eachSystem;
 
   # ensure for that all expected, but no extra attrs are present
-  validateHost = {
-      channelName ? null
+  validateHost =
+    { channelName ? null
     , system ? null
-    , modules ? []
-    , extraArgs ? {}
-  }: { inherit channelName system modules extraArgs; };
+    , output ? null
+    , builder ? null
+    , modules ? [ ]
+    , extraArgs ? { }
+    }: { inherit channelName system output builder modules extraArgs; };
 
   mergeHosts = lhs: rhs:
-  let
-    # convoluted nix-kell, but clean(er) english-german below :-)
-    _ = x: op: y: op x y;
-    oder = lhs: rhs: if lhs != null then lhs else rhs;
+    let
+      # convoluted nix-kell, but clean(er) english-german below :-)
+      _ = x: op: y: op x y;
+      oder = lhs: rhs: if lhs != null then lhs else rhs;
 
-    rhs' = { channelName = _ rhs.channelName; system = _ rhs.system; };
-    lhs' = { channelName = _ lhs.channelName; system = _ lhs.system; };
-  in 
-  {
-    channelName = rhs'.channelName oder (lhs'.channelName oder "nixpkgs") ;
-    system = rhs'.system oder (lhs'.system oder defaultSystem) ; # replace deaultSystem with x86_64-linux
-    modules = rhs.modules ++ lhs.modules ++ sharedModules;
-    extraArgs = sharedExtraArgs // lhs.extraArgs // rhs.extraArgs;
-  };
+      rhs' = {
+        channelName = _ rhs.channelName;
+        system = _ rhs.system;
+        output = _ rhs.output;
+        builder = _ rhs.builder;
+      };
+      lhs' = {
+        channelName = _ lhs.channelName;
+        system = _ lhs.system;
+        output = _ lhs.output;
+        builder = _ lhs.builder;
+      };
+    in
+    rec {
+      channelName = rhs'.channelName oder (lhs'.channelName oder "nixpkgs");
+      system = rhs'.system oder (lhs'.system oder defaultSystem); # replace deaultSystem with x86_64-linux
+      output = rhs'.output oder (lhs'.output oder "nixosConfigurations");
+      builder = rhs'.builder oder (lhs'.builder oder channels.${channelName}.input.lib.nixosSystem);
+      modules = rhs.modules ++ lhs.modules ++ sharedModules;
+      extraArgs = sharedExtraArgs // lhs.extraArgs // rhs.extraArgs;
+    };
 
   optionalAttrs = check: value: if check then value else { };
 
@@ -58,7 +72,7 @@ let
     "defaultSystem" # TODO: deprecated, remove
     "sharedExtraArgs"
     "inputs"
-    "nixosHosts"
+    "hosts"
     "hostDefaults"
     "channels"
     "channelsConfig"
@@ -75,50 +89,50 @@ let
     "checksBuilder"
   ];
 
-  nixosConfigurationBuilder = hostname: host:
-    let
-      host' =
-        mergeHosts (validateHost hostDefaults) (validateHost host);
-    in
-      # It would be nice to get `nixosSystem` reference from `selectedNixpkgs` but it is not possible at this moment
-      inputs."${host'.channelName}".lib.nixosSystem
-        (genericConfigurationBuilder hostname host');
-
   getNixpkgs = host: self.pkgs."${host.system}"."${host.channelName}";
 
-  genericConfigurationBuilder = hostname: host: (
-    let selectedNixpkgs = getNixpkgs host; in
+  configurationBuilder = hostname: host': (
+    let
+      selectedNixpkgs = getNixpkgs host;
+      host = mergeHosts (validateHost hostDefaults) (validateHost host');
+    in
     {
-      inherit (selectedNixpkgs) system;
-      modules = [
-        ({ pkgs, lib, options, ... }: {
-          # 'mkMerge` to separate out each part into its own module
-          _type = "merge";
-          contents = [
-            (optionalAttrs (options ? networking.hostName) { 
-              networking.hostName = hostname; 
-            })
+      name = host.output;
+      value.${hostname} = host.builder {
+        inherit (selectedNixpkgs) system;
+        modules = [
+          ({ pkgs, lib, options, ... }: {
+            # 'mkMerge` to separate out each part into its own module
+            _type = "merge";
+            contents = [
+              (optionalAttrs (options ? networking.hostName) {
+                networking.hostName = hostname;
+              })
 
-            (if options ? nixpkgs then {
-              nixpkgs = {
-                inherit (selectedNixpkgs) overlays config system;
-              };
-            } else { _module.args.pkgs = selectedNixpkgs; })
+              (if options ? nixpkgs then {
+                nixpkgs = {
+                  inherit (selectedNixpkgs) overlays config system;
+                };
+              } else { _module.args.pkgs = selectedNixpkgs; })
 
-            (optionalAttrs (options ? system.configurationRevision) {
-              system.configurationRevision = lib.mkIf (self ? rev) self.rev;
-            })
+              (optionalAttrs (options ? system.configurationRevision) {
+                system.configurationRevision = lib.mkIf (self ? rev) self.rev;
+              })
 
-            (optionalAttrs (options ? nix.package) { 
-              nix.package = lib.mkDefault pkgs.nixUnstable;
-            })
-          ];
-        })
-      ]
-      ++ host.modules;
-      extraArgs = { inherit inputs; } // host.extraArgs;
+              (optionalAttrs (options ? nix.package) {
+                nix.package = lib.mkDefault pkgs.nixUnstable;
+              })
+            ];
+          })
+        ] ++ host.modules;
+        extraArgs = { inherit inputs; } // host.extraArgs;
+      };
     }
   );
+
+  mapAttrs' = f: set:
+    builtins.listToAttrs (map (attr: f attr set.${attr}) (builtins.attrNames set));
+
 in
 otherArguments
 
@@ -150,8 +164,7 @@ otherArguments
   // optional devShellBuilder { devShell = devShellBuilder pkgs; }
   // optional checksBuilder { checks = checksBuilder pkgs; }
 )
-
-  // {
-  nixosConfigurations = nixosConfigurations // (builtins.mapAttrs nixosConfigurationBuilder nixosHosts);
-}
-
+  # produces attrset in the shape of
+  # { nixosConfigurations = {}; darwinConfigurations = {};  ... } 
+  # according to profile.output or the default `nixosConfigurations`
+  // mapAttrs' configurationBuilder hosts


### PR DESCRIPTION
This allows users to pass the config system they want a profile built with and the output it should go in.
So you could now do:
```
configProfiles.NixOS = {
  builder = inputs.darwin.lib.darwinSystem;
  output = "darwinConfigurations";
}
```
Also added `defaultConfigBuilder` and `defaultConfigOutput` to make this a bit easier for those that only use one system. And renamed `nixosProfiles` to `configProfiles` with the proper deprecation line. But I actually think this should be named `hosts`, and then we can go `defaultHostOutput`. Or maybe configs could work.

This will prevent flake-utils-plus making an opinion on what config system, but nixos support is probably a bit better. And this should allow for darwin and home manager support. This could also work for robotnix,  but that would require a bit more rework to `configurationBuilder`