### PR TITLE
Add argument for default host attributes

### DIFF
--- a/examples/fully-featured-flake.nix
+++ b/examples/fully-featured-flake.nix
@@ -65,6 +65,11 @@
         allowUnfree = true;
       };
 
+      # Passed to all hosts
+      defaultHostAttrs {
+        channelName = "unstable";
+      };
+
       # Profiles, gets parsed into `nixosConfigurations`
       nixosHosts = {
         # Profile name / System hostname

--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -7,6 +7,7 @@
 
 , nixosConfigurations ? { }
 , sharedExtraArgs ? { }
+, defaultHostAttrs ? { }
 , nixosProfiles ? { } # will be deprecated soon, use nixosHosts, instead.
 , nixosHosts ? nixosProfiles
 , channels ? { }
@@ -34,6 +35,7 @@ let
     "sharedExtraArgs"
     "inputs"
     "nixosHosts"
+    "defaultHostAttrs"
     "channels"
     "channelsConfig"
     "self"
@@ -57,7 +59,10 @@ let
   getNixpkgs = profile: self.pkgs."${systemFromProfile profile}"."${channelNameFromProfile profile}";
 
   genericConfigurationBuilder = hostname: profile: (
-    let selectedNixpkgs = getNixpkgs profile; in
+    let
+      selectedNixpkgs = getNixpkgs profile;
+      profileAttrs = defaultHostAttrs // profile;
+    in
     {
       inherit (selectedNixpkgs) system;
       modules = [
@@ -73,8 +78,8 @@ let
         })
       ]
       ++ sharedModules
-      ++ (profile.modules or [ ]);
-      extraArgs = { inherit inputs; } // sharedExtraArgs // profile.extraArgs or { };
+      ++ (profileAttrs.modules or [ ]);
+      extraArgs = { inherit inputs; } // sharedExtraArgs // profileAttrs.extraArgs or { };
     }
   );
 in

--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -25,10 +25,20 @@
 }@args:
 
 let
-  inherit (flake-utils-plus.lib) eachSystem;
+  evalHostArgs =
+    { channelName ? "nixpkgs"
+    , modules ? []
+    , system ? defaultSystem
+    , extraArgs ? {}
+    , ...
+    }: defaultHostAttrs
+      // { 
+        inherit channelName system; 
+        modules = sharedModules ++ modules;
+        extraArgs = sharedExtraArgs // extraArgs;
+      };
 
-  channelNameFromProfile = profile: profile.channelName or "nixpkgs";
-  systemFromProfile = profile: profile.system or defaultSystem;
+  inherit (flake-utils-plus.lib) eachSystem;
 
   otherArguments = builtins.removeAttrs args [
     "defaultSystem"
@@ -51,18 +61,15 @@ let
     "checksBuilder"
   ];
 
-  nixosConfigurationBuilder = hostname: profile: (
+  nixosConfigurationBuilder = hostname: profile: 
+    let hostAttrs = evalHostArgs profile; in
     # It would be nice to get `nixosSystem` reference from `selectedNixpkgs` but it is not possible at this moment
-    inputs."${channelNameFromProfile profile}".lib.nixosSystem (genericConfigurationBuilder hostname profile)
-  );
+    inputs."${hostAttrs.channelName}".lib.nixosSystem (genericConfigurationBuilder hostname hostAttrs);
 
-  getNixpkgs = profile: self.pkgs."${systemFromProfile profile}"."${channelNameFromProfile profile}";
+  getNixpkgs = profile: self.pkgs."${profile.system}"."${profile.channelName}";
 
   genericConfigurationBuilder = hostname: profile: (
-    let
-      selectedNixpkgs = getNixpkgs profile;
-      profileAttrs = defaultHostAttrs // profile;
-    in
+    let selectedNixpkgs = getNixpkgs profile; in
     {
       inherit (selectedNixpkgs) system;
       modules = [
@@ -77,9 +84,8 @@ let
           nix.package = lib.mkDefault pkgs.nixUnstable;
         })
       ]
-      ++ sharedModules
-      ++ (profileAttrs.modules or [ ]);
-      extraArgs = { inherit inputs; } // sharedExtraArgs // profileAttrs.extraArgs or { };
+      ++ profile.modules;
+      extraArgs = { inherit inputs; } // profile.extraArgs;
     }
   );
 in


### PR DESCRIPTION
Generic argument to add defaults to all hosts. This could cover modules, extraArgs, system, and channelName. I would say keep some things, ex `sharedModules`, just for convenience and backwards-compatibility, but this is overall useful to prevent making the api surface too large. Whenever adding things to hosts, you no longer need to make a relevant default argument, users can just use `defaultHostAttrs`.

Example:
```nix
defaultHostAttrs = {
  modules = ...;
  channeName = ...;
  system = ...;
};
```