### PR TITLE
fix: defaultHostAttrs merging

### DIFF
--- a/examples/fully-featured-flake.nix
+++ b/examples/fully-featured-flake.nix
@@ -65,6 +65,11 @@
         allowUnfree = true;
       };
 
+      # Passed to all hosts
+      defaultHostAttrs {
+        channelName = "unstable";
+      };
+
       # Profiles, gets parsed into `nixosConfigurations`
       nixosHosts = {
         # Profile name / System hostname

--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -7,6 +7,7 @@
 
 , nixosConfigurations ? { }
 , sharedExtraArgs ? { }
+, defaultHostAttrs ? { }
 , nixosProfiles ? { } # will be deprecated soon, use nixosHosts, instead.
 , nixosHosts ? nixosProfiles
 , channels ? { }
@@ -24,18 +25,29 @@
 }@args:
 
 let
+  evalHostArgs =
+    { channelName ? "nixpkgs"
+    , modules ? []
+    , system ? defaultSystem
+    , extraArgs ? {}
+    , ...
+    }: defaultHostAttrs
+      // { 
+        inherit channelName system; 
+        modules = sharedModules ++ modules;
+        extraArgs = sharedExtraArgs // extraArgs;
+      };
+
   inherit (flake-utils-plus.lib) eachSystem;
 
   optionalAttrs = check: value: if check then value else { };
-
-  channelNameFromProfile = profile: profile.channelName or "nixpkgs";
-  systemFromProfile = profile: profile.system or defaultSystem;
 
   otherArguments = builtins.removeAttrs args [
     "defaultSystem"
     "sharedExtraArgs"
     "inputs"
     "nixosHosts"
+    "defaultHostAttrs"
     "channels"
     "channelsConfig"
     "self"
@@ -51,12 +63,12 @@ let
     "checksBuilder"
   ];
 
-  nixosConfigurationBuilder = hostname: profile: (
+  nixosConfigurationBuilder = hostname: profile: 
+    let hostAttrs = evalHostArgs profile; in
     # It would be nice to get `nixosSystem` reference from `selectedNixpkgs` but it is not possible at this moment
-    inputs."${channelNameFromProfile profile}".lib.nixosSystem (genericConfigurationBuilder hostname profile)
-  );
+    inputs."${hostAttrs.channelName}".lib.nixosSystem (genericConfigurationBuilder hostname hostAttrs);
 
-  getNixpkgs = profile: self.pkgs."${systemFromProfile profile}"."${channelNameFromProfile profile}";
+  getNixpkgs = profile: self.pkgs."${profile.system}"."${profile.channelName}";
 
   genericConfigurationBuilder = hostname: profile: (
     let selectedNixpkgs = getNixpkgs profile; in
@@ -87,9 +99,8 @@ let
           ];
         })
       ]
-      ++ sharedModules
-      ++ (profile.modules or [ ]);
-      extraArgs = { inherit inputs; } // sharedExtraArgs // profile.extraArgs or { };
+      ++ profile.modules;
+      extraArgs = { inherit inputs; } // profile.extraArgs;
     }
   );
 in


### PR DESCRIPTION
###### Since we are not yet completely clear on details of this fix, I reverted the offending commit in `staging` for now and reapplied it here, so that `staging` is kept free of offending commits until we find a solution.
---
if both, defaultSystem and defaultHostAttrs.system are declared, which
should take precedence? And at any rate the other one becomes a no-op
api argument. Conditionally no-op api args are treacherous.

To avoid this sort of problems all args with an override semantic
need to be removed from top level. Currently this affects defaultSystem.

Note that since sharedModules and sharedExtraArgs have merge semantics,
they don't suffer this conflict, if both they are declared in both
places, at the very least non of them becomes a no-op.

---


Also validate API contracts (almost) properly (still no type checking).