### PR TITLE
add: defaultHostsAttrs (fixed)

### DIFF
--- a/examples/fully-featured-flake.nix
+++ b/examples/fully-featured-flake.nix
@@ -31,13 +31,13 @@
 
 
       # Default host settings.
-      defaultHostAttrs = {
+      hostDefaults = {
         # Default architecture to be used for `nixosHosts` defaults to "x86_64-linux"
         system = "aarch64-linux";
         # Default channel to be used for `nixosHosts` defaults to "nixpkgs"
         channelName = "unstable";
         # Extra arguments to be passed to modules. Merged with sharedExtraArgs on its left hand side and the host's extraArgs on its right hand side
-        extraArgs = { foo = "foo" };
+        extraArgs = { foo = "foo"; };
         # Default modules to be passed to all hosts. Equivalent to sharedModules (additive merge).
         modules = [ ];
       };

--- a/examples/fully-featured-flake.nix
+++ b/examples/fully-featured-flake.nix
@@ -65,6 +65,11 @@
         allowUnfree = true;
       };
 
+      # Passed to all hosts
+      defaultHostAttrs {
+        channelName = "unstable";
+      };
+
       # Profiles, gets parsed into `nixosConfigurations`
       nixosHosts = {
         # Profile name / System hostname

--- a/examples/somewhat-realistic-flake.nix
+++ b/examples/somewhat-realistic-flake.nix
@@ -74,16 +74,18 @@
 
 
       # Shared modules/configurations between `nixosHosts`
-      sharedModules = [
-        home-manager.nixosModules.home-manager
-        # Sets sane `nix.*` defaults. Please refer to implementation/readme for more details.
-        utils.nixosModules.saneFlakeDefaults
-        (import ./modules)
-        {
-          home-manager.useGlobalPkgs = true;
-          home-manager.useUserPackages = true;
-        }
-      ];
+      defaultHostsAttrs = {
+        modules = [
+          home-manager.nixosModules.home-manager
+          # Sets sane `nix.*` defaults. Please refer to implementation/readme for more details.
+          utils.nixosModules.saneFlakeDefaults
+          (import ./modules)
+          {
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+          }
+        ];
+      };
 
 
 

--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -7,6 +7,7 @@
 
 , nixosConfigurations ? { }
 , sharedExtraArgs ? { }
+, defaultHostAttrs ? { }
 , nixosProfiles ? { } # will be deprecated soon, use nixosHosts, instead.
 , nixosHosts ? nixosProfiles
 , channels ? { }
@@ -24,18 +25,29 @@
 }@args:
 
 let
+  evalHostArgs =
+    { channelName ? "nixpkgs"
+    , modules ? []
+    , system ? defaultSystem
+    , extraArgs ? {}
+    , ...
+    }: defaultHostAttrs
+      // { 
+        inherit channelName system; 
+        modules = sharedModules ++ modules;
+        extraArgs = sharedExtraArgs // extraArgs;
+      };
+
   inherit (flake-utils-plus.lib) eachSystem;
 
   optionalAttrs = check: value: if check then value else { };
-
-  channelNameFromProfile = profile: profile.channelName or "nixpkgs";
-  systemFromProfile = profile: profile.system or defaultSystem;
 
   otherArguments = builtins.removeAttrs args [
     "defaultSystem"
     "sharedExtraArgs"
     "inputs"
     "nixosHosts"
+    "defaultHostAttrs"
     "channels"
     "channelsConfig"
     "self"
@@ -51,12 +63,12 @@ let
     "checksBuilder"
   ];
 
-  nixosConfigurationBuilder = hostname: profile: (
+  nixosConfigurationBuilder = hostname: profile: 
+    let hostAttrs = evalHostArgs profile; in
     # It would be nice to get `nixosSystem` reference from `selectedNixpkgs` but it is not possible at this moment
-    inputs."${channelNameFromProfile profile}".lib.nixosSystem (genericConfigurationBuilder hostname profile)
-  );
+    inputs."${hostAttrs.channelName}".lib.nixosSystem (genericConfigurationBuilder hostname hostAttrs);
 
-  getNixpkgs = profile: self.pkgs."${systemFromProfile profile}"."${channelNameFromProfile profile}";
+  getNixpkgs = profile: self.pkgs."${profile.system}"."${profile.channelName}";
 
   genericConfigurationBuilder = hostname: profile: (
     let selectedNixpkgs = getNixpkgs profile; in
@@ -87,9 +99,8 @@ let
           ];
         })
       ]
-      ++ sharedModules
-      ++ (profile.modules or [ ]);
-      extraArgs = { inherit inputs; } // sharedExtraArgs // profile.extraArgs or { };
+      ++ profile.modules;
+      extraArgs = { inherit inputs; } // profile.extraArgs;
     }
   );
 in

--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -75,15 +75,15 @@ let
     extraArgs = sharedExtraArgs // defaultAttrs.extraArgs // extraArgs;
   };
 
-  nixosConfigurationBuilder = hostname: profile: 
+  nixosConfigurationBuilder = hostname: hostAttrs: 
     let hostAttrs = mergeHostAttrs (validateHostAttrs defaultHostAttrs) (validateHostAttrs profile); in
     # It would be nice to get `nixosSystem` reference from `selectedNixpkgs` but it is not possible at this moment
     inputs."${hostAttrs.channelName}".lib.nixosSystem (genericConfigurationBuilder hostname hostAttrs);
 
-  getNixpkgs = profile: self.pkgs."${profile.system}"."${profile.channelName}";
+  getNixpkgs = hostAttrs: self.pkgs."${hostAttrs.system}"."${hostAttrs.channelName}";
 
-  genericConfigurationBuilder = hostname: profile: (
-    let selectedNixpkgs = getNixpkgs profile; in
+  genericConfigurationBuilder = hostname: hostAttrs: (
+    let selectedNixpkgs = getNixpkgs hostAttrs; in
     {
       inherit (selectedNixpkgs) system;
       modules = [
@@ -111,8 +111,8 @@ let
           ];
         })
       ]
-      ++ profile.modules;
-      extraArgs = { inherit inputs; } // profile.extraArgs;
+      ++ hostAttrs.modules;
+      extraArgs = { inherit inputs; } // hostAttrs.extraArgs;
     }
   );
 in

--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -25,20 +25,27 @@
 }@args:
 
 let
-  # clean dirty api input / ensure for that all expected, but no extra attrs are present
+  # ensure for that all expected, but no extra attrs are present
   validateHostAttrs = {
       channelName ? null
     , system ? null
     , modules ? []
     , extraArgs ? {}
-  } @ args: { inherit channelName system modules extraArgs; };
+  }: { inherit channelName system modules extraArgs; };
 
   mergeHostAttrs = defaultAttrs: attrs: let
-    defaultTo = lhs: rhs: if rhs != null then rhs else lhs;
+    # convoluted nix-kell, but clean(er) english-german below :-)
+    _ = x: op: y: op x y;
+    oder = lhs: rhs: if lhs != null then lhs else rhs;
+
+    attrs.channelName' = _ attrs.channelName;
+    defaultAttrs.channelName' = _ defaultAttrs.channelName;
+    attrs.system' = _ attrs.system;
+    defaultAttrs.system' = _ defaultAttrs.system;
   in
   {
-    channelName = defaultTo (defaultTo "nixpkgs" defaultAttrs.channelName) attrs.channelName;
-    system = defaultTo (defaultTo defaultSystem defaultAttrs.system) attrs.system; # replace deaultSystem with x86_64-linux
+    channelName = attrs.channelName' oder (defaultAttrs.channelName' oder "nixpkgs") ;
+    system = attrs.system' oder (defaultAttrs.system' oder defaultSystem) ; # replace deaultSystem with x86_64-linux
     modules = modules ++ defaultAttrs.modules ++ sharedModules;
     extraArgs = sharedExtraArgs // defaultAttrs.extraArgs // extraArgs;
   };

--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -33,23 +33,6 @@ let
     , extraArgs ? {}
   }: { inherit channelName system modules extraArgs; };
 
-  mergeHostAttrs = defaultAttrs: attrs: let
-    # convoluted nix-kell, but clean(er) english-german below :-)
-    _ = x: op: y: op x y;
-    oder = lhs: rhs: if lhs != null then lhs else rhs;
-
-    attrs.channelName' = _ attrs.channelName;
-    defaultAttrs.channelName' = _ defaultAttrs.channelName;
-    attrs.system' = _ attrs.system;
-    defaultAttrs.system' = _ defaultAttrs.system;
-  in
-  {
-    channelName = attrs.channelName' oder (defaultAttrs.channelName' oder "nixpkgs") ;
-    system = attrs.system' oder (defaultAttrs.system' oder defaultSystem) ; # replace deaultSystem with x86_64-linux
-    modules = modules ++ defaultAttrs.modules ++ sharedModules;
-    extraArgs = sharedExtraArgs // defaultAttrs.extraArgs // extraArgs;
-  };
-
   inherit (flake-utils-plus.lib) eachSystem;
 
   optionalAttrs = check: value: if check then value else { };
@@ -74,6 +57,23 @@ let
     "devShellBuilder"
     "checksBuilder"
   ];
+
+  mergeHostAttrs = defaultAttrs: attrs: let
+    # convoluted nix-kell, but clean(er) english-german below :-)
+    _ = x: op: y: op x y;
+    oder = lhs: rhs: if lhs != null then lhs else rhs;
+
+    attrs.channelName' = _ attrs.channelName;
+    defaultAttrs.channelName' = _ defaultAttrs.channelName;
+    attrs.system' = _ attrs.system;
+    defaultAttrs.system' = _ defaultAttrs.system;
+  in
+  {
+    channelName = attrs.channelName' oder (defaultAttrs.channelName' oder "nixpkgs") ;
+    system = attrs.system' oder (defaultAttrs.system' oder defaultSystem) ; # replace deaultSystem with x86_64-linux
+    modules = modules ++ defaultAttrs.modules ++ sharedModules;
+    extraArgs = sharedExtraArgs // defaultAttrs.extraArgs // extraArgs;
+  };
 
   nixosConfigurationBuilder = hostname: profile: 
     let hostAttrs = mergeHostAttrs (validateHostAttrs defaultHostAttrs) (validateHostAttrs profile); in

--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -40,7 +40,7 @@ let
     channelName = defaultTo (defaultTo "nixpkgs" defaultAttrs.channelName) attrs.channelName;
     system = defaultTo (defaultTo defaultSystem defaultAttrs.system) attrs.system; # replace deaultSystem with x86_64-linux
     modules = modules ++ defaultAttrs.modules ++ sharedModules;
-    extraArgs = extraArgs // defaultAttrs.extraArgs // sharedExtraArgs;
+    extraArgs = sharedExtraArgs // defaultAttrs.extraArgs // extraArgs;
   };
 
   inherit (flake-utils-plus.lib) eachSystem;


### PR DESCRIPTION
###### https://github.com/gytis-ivaskevicius/flake-utils-plus/commit/faa78550684ffbce1aab0f1df7d257f74f231588 unintentionally introduced non-functional business logic into `staging`. To keep staging clean, I reverted it in https://github.com/gytis-ivaskevicius/flake-utils-plus/commit/fe983e5a9cd4039b48e03f7c7e88ac750ebb2457 until we find a better solution. This is an attempt to improve on the previous implementation. As such, this supersedes #21, which was trying to be a fix only.

---


As the `fup` api grows, we need a better way to ensure consistency.

Currently top level has a mix of host-specific and channel-specific defaults. However, we expect host specific defaults to grow in the near future (eg. #17) and it would not be in order to just clutter the top level arguments.

This PR introduces a (reusable) API container and thereby transparently exposes the current `profile/host` `fup`-API-objet. For clarity, it currently is:
```nix
{
  profile = {
    channelName = "...";
    system = "...";
    extraArgs = {};
    modules = [];
  };
}
```

This PR generalizes this API, implements a minimal validation (expected args of the profile/host API object are present and unexpected args aren't) and consequentially, applies it analogously to a new `defaultHostAttrs`.

`defaultsHostAttrs` deprecated `defaultSystem`, because there is no way to prevent `defaultSystem` from becoming an obsolete no-op in the case that also `defaultSystem.system` is set. That would result in a very unclean API.

However, as `modules` and `extraArgs` obey merging semantics, `sharedModules` (`add`) & `sharedExtraArgs` (`merge`) are preserved as a convenient way of declaration and also to underline the _shared_ nature of them. And also for back-compat.

The exact merging semantics are encapsualted within `mergeHostAttrs` and are:
- system & channelName: more specific declartion's override
- modules: all declarations add
- extraArgs: declarations are merged and more specific declarations override in case of conflicting keys

`mergeHostAttrs` also implements the hard coded defaults for `channelName` and `system` (currently `defaultSystem` is only marked deprecated).

---

While working on this, I also realized that `profile` represents a `fup` specific api container, and does not represent a host config or a host profile. Hence, it might be in order to evaluate how we should properly name the following attribute set in a future discussion.
```nix
{
    channelName = "...";
    system = "...";
    extraArgs = {};
    modules = [];
}