### PR TITLE
imp: add specialArgs

### DIFF
--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -36,7 +36,8 @@ let
     , builder ? null
     , modules ? [ ]
     , extraArgs ? { }
-    }: { inherit channelName system output builder modules extraArgs; };
+    , specialArgs ? { }
+    }: { inherit channelName system output builder modules extraArgs specialArgs; };
 
   mergeHosts = lhs: rhs:
     let
@@ -64,6 +65,7 @@ let
       builder = rhs'.builder oder (lhs'.builder oder channels.${channelName}.input.lib.nixosSystem);
       modules = rhs.modules ++ lhs.modules ++ sharedModules;
       extraArgs = sharedExtraArgs // lhs.extraArgs // rhs.extraArgs;
+      specialArgs = lhs.specialArgs // rhs.specialArgs;
     };
 
   optionalAttrs = check: value: if check then value else { };
@@ -130,6 +132,7 @@ let
             ];
           })
         ] ++ host.modules;
+        specialArgs = host.specialArgs;
       };
     }
   );


### PR DESCRIPTION
anything that is going to be passed to an `imports = []` necesarily
needs to be passed as specialArgs. This ensures it does not become
part of the module system (extraArgs = _module.args) itself.

Since it is not part of the module system, modules can evaluate based on
inputs, otherwise no fixed point would exists (infinit recursion).

This is a way to encapsulate profiles into bundles that are accessible
like so:

inputs = [ bundles.home ];