### PR TITLE
implement builtinPackagesBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ This flake provides two main features (visible from `flake.nix`):
 
 - `nixosModules.saneFlakeDefaults` - Configures `nix.*` attributes. Generates `nix.nixPath`/`nix.registry` from flake `inputs`, sets `pkgs.nixUnstable` as the default also enables `ca-references` and `flakes`.
 - `lib.systemFlake { ... }` - Generates a system flake that may then be built.
-- `lib.modulesFromList [ ./a.nix ./b.nix ]` - Generates modules attributes which looks like this `{ a = import ./a.nix; b = import ./b.nix; }`.
+- `lib.exporter.modulesFromListExporter [ ./a.nix ./b.nix ]` - Generates modules attributes which looks like this `{ a = import ./a.nix; b = import ./b.nix; }`.
+- `lib.exporter.overlaysFromChannelsExporter channels` - Collects all overlays from channels and exports them as an appropriately namespaced attribute set. Users can instantiate with their nixpkgs version.
+- `lib.builder.packagesFromOverlayBuilderConstructor channels pkgs` - Similar to the overlay generator, but outputs them as packages, instead. Users can use your cache.
 
 
 # Examples #

--- a/flake.nix
+++ b/flake.nix
@@ -4,19 +4,6 @@
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = { self, flake-utils }:
-    let
-      removeSuffix = suffix: str:
-        let
-          sufLen = builtins.stringLength suffix;
-          sLen = builtins.stringLength str;
-        in
-        if sufLen <= sLen && suffix == builtins.substring (sLen - sufLen) sufLen str then
-          builtins.substring 0 (sLen - sufLen) str
-        else
-          str;
-
-      genAttrs' = func: values: builtins.listToAttrs (map func values);
-    in
     rec {
 
       nixosModules.saneFlakeDefaults = import ./modules/saneFlakeDefaults.nix;
@@ -26,12 +13,9 @@
         repl = ./repl.nix;
         systemFlake = import ./systemFlake.nix { flake-utils-plus = self; };
 
-        modulesFromList = paths: genAttrs'
-          (path: {
-            name = removeSuffix ".nix" (baseNameOf path);
-            value = import path;
-          })
-          paths;
+        exporter = {
+          modulesFromListExporter = import ./modulesFromListExporter.nix { flake-utils-plus = self; };
+        };
 
         patchChannel = system: channel: patches:
           if patches == [ ] then channel else

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,7 @@
         systemFlake = import ./systemFlake.nix { flake-utils-plus = self; };
 
         exporter = {
+          overlaysFromChannelsExporter = import ./overlaysFromChannelsExporter.nix { flake-utils-plus = self; };
           modulesFromListExporter = import ./modulesFromListExporter.nix { flake-utils-plus = self; };
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,10 @@
         repl = ./repl.nix;
         systemFlake = import ./systemFlake.nix { flake-utils-plus = self; };
 
+        builder = {
+          packagesFromOverlaysBuilderConstructor = import ./packagesFromOverlaysBuilderConstructor.nix { flake-utils-plus = self; };
+        };
+
         exporter = {
           overlaysFromChannelsExporter = import ./overlaysFromChannelsExporter.nix { flake-utils-plus = self; };
           modulesFromListExporter = import ./modulesFromListExporter.nix { flake-utils-plus = self; };

--- a/moduleFromListExporter.nix
+++ b/moduleFromListExporter.nix
@@ -1,0 +1,29 @@
+{ flake-utils-plus }: let
+
+modulesFromListExporter =
+
+  let
+
+    removeSuffix = suffix: str:
+      let
+        sufLen = builtins.stringLength suffix;
+        sLen = builtins.stringLength str;
+      in
+      if sufLen <= sLen && suffix == builtins.substring (sLen - sufLen) sufLen str then
+        builtins.substring 0 (sLen - sufLen) str
+      else
+        str;
+
+    genAttrs' = func: values: builtins.listToAttrs (map func values);
+
+  in
+
+    paths: genAttrs'
+      (path: {
+        name = removeSuffix ".nix" (baseNameOf path);
+        value = import path;
+      })
+      paths;
+
+in
+modulesFromListExporter

--- a/moduleFromListExporter.nix
+++ b/moduleFromListExporter.nix
@@ -1,24 +1,25 @@
-{ flake-utils-plus }: let
+{ flake-utils-plus }:
+let
 
   modulesFromListExporter = paths:
     /**
-    Synopsis: modulesFromListExporter _paths_
+      Synopsis: modulesFromListExporter _paths_
 
-    paths:    [ <path> <path> ]
+      paths:    [ <path> <path> ]
 
-    Returns an attribute set of modules from a list of paths by converting
-    the path's basename into the attribute key.
+      Returns an attribute set of modules from a list of paths by converting
+      the path's basename into the attribute key.
 
-    Example:
+      Example:
 
-    paths:    [ ./path/to/moduleA.nix ./path/to/moduleBfolder ]
+      paths:    [ ./path/to/moduleA.nix ./path/to/moduleBfolder ]
 
-    {
+      {
       moduleA = import ./path/to/moduleA.nix;
       moduleBfolder = import ./path/to/moduleBfolder;
-    }
+      }
 
-    **/
+      **/
 
     let
 
@@ -36,12 +37,12 @@
 
     in
 
-      genAttrs'
-        (path: {
-          name = removeSuffix ".nix" (baseNameOf path);
-          value = import path;
-        })
-        paths;
+    genAttrs'
+      (path: {
+        name = removeSuffix ".nix" (baseNameOf path);
+        value = import path;
+      })
+      paths;
 
 in
 modulesFromListExporter

--- a/moduleFromListExporter.nix
+++ b/moduleFromListExporter.nix
@@ -1,29 +1,47 @@
 { flake-utils-plus }: let
 
-modulesFromListExporter =
+  modulesFromListExporter = paths:
+    /**
+    Synopsis: modulesFromListExporter _paths_
 
-  let
+    paths:    [ <path> <path> ]
 
-    removeSuffix = suffix: str:
-      let
-        sufLen = builtins.stringLength suffix;
-        sLen = builtins.stringLength str;
-      in
-      if sufLen <= sLen && suffix == builtins.substring (sLen - sufLen) sufLen str then
-        builtins.substring 0 (sLen - sufLen) str
-      else
-        str;
+    Returns an attribute set of modules from a list of paths by converting
+    the path's basename into the attribute key.
 
-    genAttrs' = func: values: builtins.listToAttrs (map func values);
+    Example:
 
-  in
+    paths:    [ ./path/to/moduleA.nix ./path/to/moduleBfolder ]
 
-    paths: genAttrs'
-      (path: {
-        name = removeSuffix ".nix" (baseNameOf path);
-        value = import path;
-      })
-      paths;
+    {
+      moduleA = import ./path/to/moduleA.nix;
+      moduleBfolder = import ./path/to/moduleBfolder;
+    }
+
+    **/
+
+    let
+
+      removeSuffix = suffix: str:
+        let
+          sufLen = builtins.stringLength suffix;
+          sLen = builtins.stringLength str;
+        in
+        if sufLen <= sLen && suffix == builtins.substring (sLen - sufLen) sufLen str then
+          builtins.substring 0 (sLen - sufLen) str
+        else
+          str;
+
+      genAttrs' = func: values: builtins.listToAttrs (map func values);
+
+    in
+
+      genAttrs'
+        (path: {
+          name = removeSuffix ".nix" (baseNameOf path);
+          value = import path;
+        })
+        paths;
 
 in
 modulesFromListExporter

--- a/overlaysFromChannelsExporter.nix
+++ b/overlaysFromChannelsExporter.nix
@@ -1,0 +1,61 @@
+{ flake-utils-plus }: let
+
+ overlaysFromChannelsExporter = channels:
+  /**
+  Synopsis: overlaysFromChannelsExporter _channels_
+
+  channels: channels.<name>.overlays
+
+  Returns an attribute set of all packages defined in an overlay by any channel
+  intended to be passed to be exported via _self.overlays_. This method of
+  sharing has the advantage over _self.packages_, that the user will instantiate
+  overlays with his proper nixpkgs version, and thereby significantly reduce their system's
+  closure as they avoid depending on entirely different nixpkgs versions dependency
+  trees. On the flip side, any caching that is set up for one's packages will essentially
+  be useless to users.
+
+  It can happen that an overlay is not compatible with the version of nixpkgs a user tries
+  to instantiate it. In order to provide users with a visual clue for which nixpkgs version
+  an overlay was originally created, we prefix the channle name: "<channelname>/<packagekey>".
+  In the case of the unstable channel, this information is still of varying usefulness,
+  as effective cut dates can vary heavily between repositories.
+
+  Example:
+
+  overlays = [
+    "unstable/development" = final: prev: { };
+    "nixos2009/chromium" = final: prev: { };
+    "nixos2009/pythonPackages" = final: prev: { };
+  ];
+
+  **/
+  let
+    inherit (builtins) mapAttrs attrNames concatMap listToAttrs;
+    nameValuePair = name: value: { inherit name value; };
+
+    pathStr = builtins.concatStringsSep "/" path;
+
+    channelNames = attrNames channels;
+    overlayNames = overlay: attrNames ( overlay null null );
+
+    extractAndNamespaceEachOverlay = channelName: overlay:
+      map (ovrlName:
+        nameValuePair
+          ( pathStr [ channelName ovrlName ] )
+          ( final: prev: {
+            ${ovrlName} = (overlay final prev).${ovrlName};
+          })
+      )
+      (overlayNames overlay);
+
+  in
+    listToAttrs (
+      concatMap (channelName:
+        concatMap (ovrl:
+          extractAndNamespaceEachOverlay channelName ovrl
+        ) channels.${channelName}.overlays
+      ) channelNames
+    );
+
+in
+overlaysFromChannelsExporter

--- a/overlaysFromChannelsExporter.nix
+++ b/overlaysFromChannelsExporter.nix
@@ -33,7 +33,7 @@
     inherit (builtins) mapAttrs attrNames concatMap listToAttrs;
     nameValuePair = name: value: { inherit name value; };
 
-    pathStr = builtins.concatStringsSep "/" path;
+    pathStr = path: builtins.concatStringsSep "/" path;
 
     channelNames = attrNames channels;
     overlayNames = overlay: attrNames ( overlay null null );

--- a/overlaysFromChannelsExporter.nix
+++ b/overlaysFromChannelsExporter.nix
@@ -1,60 +1,66 @@
-{ flake-utils-plus }: let
+{ flake-utils-plus }:
+let
 
- overlaysFromChannelsExporter = channels:
-  /**
-  Synopsis: overlaysFromChannelsExporter _channels_
+  overlaysFromChannelsExporter = channels:
+    /**
+      Synopsis: overlaysFromChannelsExporter _channels_
 
-  channels: channels.<name>.overlays
+      channels: channels.<name>.overlays
 
-  Returns an attribute set of all packages defined in an overlay by any channel
-  intended to be passed to be exported via _self.overlays_. This method of
-  sharing has the advantage over _self.packages_, that the user will instantiate
-  overlays with his proper nixpkgs version, and thereby significantly reduce their system's
-  closure as they avoid depending on entirely different nixpkgs versions dependency
-  trees. On the flip side, any caching that is set up for one's packages will essentially
-  be useless to users.
+      Returns an attribute set of all packages defined in an overlay by any channel
+      intended to be passed to be exported via _self.overlays_. This method of
+      sharing has the advantage over _self.packages_, that the user will instantiate
+      overlays with his proper nixpkgs version, and thereby significantly reduce their system's
+      closure as they avoid depending on entirely different nixpkgs versions dependency
+      trees. On the flip side, any caching that is set up for one's packages will essentially
+      be useless to users.
 
-  It can happen that an overlay is not compatible with the version of nixpkgs a user tries
-  to instantiate it. In order to provide users with a visual clue for which nixpkgs version
-  an overlay was originally created, we prefix the channle name: "<channelname>/<packagekey>".
-  In the case of the unstable channel, this information is still of varying usefulness,
-  as effective cut dates can vary heavily between repositories.
+      It can happen that an overlay is not compatible with the version of nixpkgs a user tries
+      to instantiate it. In order to provide users with a visual clue for which nixpkgs version
+      an overlay was originally created, we prefix the channle name: "<channelname>/<packagekey>".
+      In the case of the unstable channel, this information is still of varying usefulness,
+      as effective cut dates can vary heavily between repositories.
 
-  Example:
+      Example:
 
-  overlays = [
-    "unstable/development" = final: prev: { };
-    "nixos2009/chromium" = final: prev: { };
-    "nixos2009/pythonPackages" = final: prev: { };
-  ];
+      overlays = [
+      "unstable/development" = final: prev: { };
+      "nixos2009/chromium" = final: prev: { };
+      "nixos2009/pythonPackages" = final: prev: { };
+      ];
 
-  **/
-  let
-    inherit (builtins) mapAttrs attrNames concatMap listToAttrs;
-    nameValuePair = name: value: { inherit name value; };
+      **/
+    let
+      inherit (builtins) mapAttrs attrNames concatMap listToAttrs;
+      nameValuePair = name: value: { inherit name value; };
 
-    pathStr = path: builtins.concatStringsSep "/" path;
+      pathStr = path: builtins.concatStringsSep "/" path;
 
-    channelNames = attrNames channels;
-    overlayNames = overlay: attrNames ( overlay null null );
+      channelNames = attrNames channels;
+      overlayNames = overlay: attrNames (overlay null null);
 
-    extractAndNamespaceEachOverlay = channelName: overlay:
-      map (overlayName:
-        nameValuePair
-          ( pathStr [ channelName overlayName ] )
-          ( final: prev: {
-            ${overlayName} = (overlay final prev).${overlayName};
-          })
-      )
-      (overlayNames overlay);
+      extractAndNamespaceEachOverlay = channelName: overlay:
+        map
+          (overlayName:
+            nameValuePair
+              (pathStr [ channelName overlayName ])
+              (final: prev: {
+                ${overlayName} = (overlay final prev).${overlayName};
+              })
+          )
+          (overlayNames overlay);
 
-  in
+    in
     listToAttrs (
-      concatMap (channelName:
-        concatMap (overlay:
-          extractAndNamespaceEachOverlay channelName overlay
-        ) channels.${channelName}.overlays
-      ) channelNames
+      concatMap
+        (channelName:
+          concatMap
+            (overlay:
+              extractAndNamespaceEachOverlay channelName overlay
+            )
+            channels.${channelName}.overlays
+        )
+        channelNames
     );
 
 in

--- a/overlaysFromChannelsExporter.nix
+++ b/overlaysFromChannelsExporter.nix
@@ -39,11 +39,11 @@
     overlayNames = overlay: attrNames ( overlay null null );
 
     extractAndNamespaceEachOverlay = channelName: overlay:
-      map (ovrlName:
+      map (overlayName:
         nameValuePair
-          ( pathStr [ channelName ovrlName ] )
+          ( pathStr [ channelName overlayName ] )
           ( final: prev: {
-            ${ovrlName} = (overlay final prev).${ovrlName};
+            ${overlayName} = (overlay final prev).${overlayName};
           })
       )
       (overlayNames overlay);
@@ -51,8 +51,8 @@
   in
     listToAttrs (
       concatMap (channelName:
-        concatMap (ovrl:
-          extractAndNamespaceEachOverlay channelName ovrl
+        concatMap (overlay:
+          extractAndNamespaceEachOverlay channelName overlay
         ) channels.${channelName}.overlays
       ) channelNames
     );

--- a/packagesFromOverlaysBuilderConstructor.nix
+++ b/packagesFromOverlaysBuilderConstructor.nix
@@ -1,86 +1,92 @@
-{ flake-utils-plus }: let
+{ flake-utils-plus }:
+let
 
- overlayFromPackagesBuilderConstructor = channels: let
-   # channels: channels.<name>.overlays
-
-   overlayFromPackagesBuilder = pkgs:
-    /**
-    Synopsis: overlayFromPackagesBuilder _pkgs_
-
-    pkgs:     pkgs.<system>.<tree>
-
-    Returns valid packges that have been defined within an overlay so they
-    can be shared via _self.packages_ with the world. This is especially useful
-    over sharing one's art via _self.overlays_ in case you have a binary cache
-    running from which third parties could benefit.
-
-    First, flattens an arbitrarily nested _pkgs_ tree for each system into a flat
-    key in which nesting is aproximated by a "/" (e.g. "development/kakoune").
-    Also filter the resulting packages for attributes that _trivially_ would
-    fail flake checks (broken, system not supported or not a derivation).
-
-    Second, collects all overlays' packages' keys of all channels into a flat list.
-
-    Finally, only passes packages through the seive that are prefixed with a top level
-    key exposed by any of the overlays. Since overlays override (and do not emrge)
-    top level attributes, by filtering on the prefix, an overlay's entire packages
-    tree will be correctly captured.
-
-    Example:
-
-    pkgs'.<system> = {
-      "development/kakoune" = { ... };
-      "development/vim" = { ... };
-    };
-
-    overlays' = [
-      "development"
-    ];
-
-    overlays' will pass both pkgs' through the sieve.
-
-    **/
+  overlayFromPackagesBuilderConstructor = channels:
     let
+      # channels: channels.<name>.overlays
 
-      inherit (flake-utils-plus.lib) flattenTree filterPackages;
-      inherit (builtins) attrNames mapAttrs listToAttrs attrValues concatStringSep concatMap any;
-      nameValuePair = name: value: { inherit name value; };
-      filterAttrs = pred: set:
-        listToAttrs (concatMap (name: let v = set.${name}; in if pred name v then [(nameValuePair name v)] else []) (attrNames set));
-      hasPrefix =
-        pref:
-        str: builtins.substring 0 (builtins.stringLength pref) str == pref;
+      overlayFromPackagesBuilder = pkgs:
+        /**
+          Synopsis: overlayFromPackagesBuilder _pkgs_
 
+          pkgs:     pkgs.<system>.<tree>
 
-      # first, flatten and filter on valid packages (by nix flake check criterion)
-      flattenedPackages =
+          Returns valid packges that have been defined within an overlay so they
+          can be shared via _self.packages_ with the world. This is especially useful
+          over sharing one's art via _self.overlays_ in case you have a binary cache
+          running from which third parties could benefit.
+
+          First, flattens an arbitrarily nested _pkgs_ tree for each system into a flat
+          key in which nesting is aproximated by a "/" (e.g. "development/kakoune").
+          Also filter the resulting packages for attributes that _trivially_ would
+          fail flake checks (broken, system not supported or not a derivation).
+
+          Second, collects all overlays' packages' keys of all channels into a flat list.
+
+          Finally, only passes packages through the seive that are prefixed with a top level
+          key exposed by any of the overlays. Since overlays override (and do not emrge)
+          top level attributes, by filtering on the prefix, an overlay's entire packages
+          tree will be correctly captured.
+
+          Example:
+
+          pkgs'.<system> = {
+          "development/kakoune" = { ... };
+          "development/vim" = { ... };
+          };
+
+          overlays' = [
+          "development"
+          ];
+
+          overlays' will pass both pkgs' through the sieve.
+
+          **/
         let
-          f = system: tree: (filterPackages system (flattenTree tree));
-        in
-        mapAttrs f pkgs;
 
-      # second, flatten all overlays' packages' keys into a single list
-      flattendOverlaysNames =
-        let
-          allOverlays = concatMap (c: c.overlays) (attrValues channels);
+          inherit (flake-utils-plus.lib) flattenTree filterPackages;
+          inherit (builtins) attrNames mapAttrs listToAttrs attrValues concatStringSep concatMap any;
+          nameValuePair = name: value: { inherit name value; };
+          filterAttrs = pred: set:
+            listToAttrs (concatMap (name: let v = set.${name}; in if pred name v then [ (nameValuePair name v) ] else [ ]) (attrNames set));
+          hasPrefix =
+            pref:
+            str: builtins.substring 0 (builtins.stringLength pref) str == pref;
 
-          overlayNamesList = overlay:
-            attrNames (overlay null null);
+
+          # first, flatten and filter on valid packages (by nix flake check criterion)
+          flattenedPackages =
+            let
+              f = system: tree: (filterPackages system (flattenTree tree));
+            in
+            mapAttrs f pkgs;
+
+          # second, flatten all overlays' packages' keys into a single list
+          flattendOverlaysNames =
+            let
+              allOverlays = concatMap (c: c.overlays) (attrValues channels);
+
+              overlayNamesList = overlay:
+                attrNames (overlay null null);
+            in
+            concatMap (o: overlayNamesList o) allOverlays;
+
         in
-          concatMap (o: overlayNamesList o) allOverlays;
+        # finally, only retain those packages defined by overlays
+          # pkgs'.<system>.<prefix/flattend/tree/attributes>
+          # overlays' = [ "prefix" ... ];
+        mapAttrs
+          (_: pkgs:
+            filterAttrs
+              (pkgName:
+                any (overlayName: hasPrefix pkgName overlayName) flattendOverlaysNames
+              )
+              pkgs
+          )
+          flattenedPackages;
 
     in
-      # finally, only retain those packages defined by overlays
-      # pkgs'.<system>.<prefix/flattend/tree/attributes>
-      # overlays' = [ "prefix" ... ];
-      mapAttrs (_: pkgs:
-        filterAttrs (pkgName:
-          any (overlayName: hasPrefix pkgName overlayName) flattendOverlaysNames
-        ) pkgs
-      ) flattenedPackages;
-
-  in
-  overlayFromPackagesBuilder;
+    overlayFromPackagesBuilder;
 
 in
 overlayFromPackagesBuilderConstructor

--- a/packagesFromOverlaysBuilderConstructor.nix
+++ b/packagesFromOverlaysBuilderConstructor.nix
@@ -100,7 +100,7 @@
       # overlays' = [ "prefix" ... ];
       builtins.mapAttrs (_: pkgs:
         filterAttrs (name:
-          builtins.any (ovrl: builtins.hasPrefix name ovrl) overlays'
+          builtins.any (overlay: builtins.hasPrefix name overlay) overlays'
         ) pkgs
       ) pkgs';
 

--- a/packagesFromOverlaysBuilderConstructor.nix
+++ b/packagesFromOverlaysBuilderConstructor.nix
@@ -1,0 +1,111 @@
+{ flake-utils-plus }: let
+
+ overlayFromPackagesBuilderConstructor = channels: let
+   # channels: channels.<name>.overlays
+
+   overlayFromPackagesBuilder = pkgs:
+    /**
+    Synopsis: overlayFromPackagesBuilder _pkgs_
+
+    pkgs:     pkgs.<system>.<tree>
+
+    Returns valid packges that have been defined within an overlay so they
+    can be shared via _self.packages_ with the world. This is especially useful
+    over sharing one's art via _self.overlays_ in case you have a binary cache
+    running from which third parties could benefit.
+
+    First, flattens an arbitrarily nested _pkgs_ tree for each system into a flat
+    key in which nesting is aproximated by a "/" (e.g. "development/kakoune").
+    Also filter the resulting packages for attributes that _trivially_ would
+    fail flake checks (broken, system not supported or not a derivation).
+
+    Second, collects all overlays' packages' keys of all channels into a flat list.
+
+    Finally, only passes packages through the seive that are prefixed with a top level
+    key exposed by any of the overlays. Since overlays override (and do not emrge)
+    top level attributes, by filtering on the prefix, an overlay's entire packages
+    tree will be correctly captured.
+
+    Example:
+
+    pkgs'.<system> = {
+      "development/kakoune" = { ... };
+      "development/vim" = { ... };
+    };
+
+    overlays' = [
+      "development"
+    ];
+
+    overlays' will pass both pkgs' through the sieve.
+
+    **/
+    let
+
+      # first, flatten and filter on valid packages (by nix flake check criterion)
+      pkgs' =
+        let
+
+          inherit (flake-utils-plus.lib) flattenTree filterPackages;
+          inherit (builtins) mapAttrs;
+
+          flattenTreeFilterSystem = pkgs:
+            let
+              f = system: tree: (filterPackages system (flattenTree tree));
+            in
+              mapAttrs f pkgs;
+        in
+        flattenTreeFilterSystem pkgs;
+
+      # second, flatten all overlays' packages' keys into a single list
+      overlays' = channels:
+        let
+
+          inherit (builtins) attrNames mapAttrs attrValues concatStringSep concatMap;
+
+          overlayNamesList = overlay:
+            let
+              f = overlay:
+                attrsNames (overlay null null);
+            in
+              mapAttrs f overlay;
+
+          overlays = map (c: c.overlays) (attrValues channels);
+
+          flattendOverlaysNames =
+            let
+              f = _: overlays:
+                concatMap (o: overlayNamesList o) overlays;
+            in
+              concatMap f overlays;
+
+        in
+          flattendOverlaysNames;
+
+    in
+      # finally, only retain those packages defined by overlays
+      let
+
+        nameValuePair = name: value: { inherit name value; };
+
+        filterAttrs = pred: set:
+          listToAttrs (concatMap (name: let v = set.${name}; in if pred name v then [(nameValuePair name v)] else []) (attrNames set));
+
+        hasPrefix =
+          pref:
+          str: builtins.substring 0 (builtins.stringLength pref) str == pref;
+
+      in
+      # pkgs'.<system>.<prefix/flattend/tree/attributes>
+      # overlays' = [ "prefix" ... ];
+      builtins.mapAttrs (_: pkgs:
+        filterAttrs (name:
+          builtins.any (ovrl: builtins.hasPrefix name ovrl) overlays'
+        ) pkgs
+      ) pkgs';
+
+  in
+  overlayFromPackagesBuilder;
+
+in
+overlayFromPackagesBuilderConstructor

--- a/packagesFromOverlaysBuilderConstructor.nix
+++ b/packagesFromOverlaysBuilderConstructor.nix
@@ -43,7 +43,7 @@
     let
 
       inherit (flake-utils-plus.lib) flattenTree filterPackages;
-      inherit (builtins) attrNames mapAttrs attrValues concatStringSep concatMap any;
+      inherit (builtins) attrNames mapAttrs listToAttrs attrValues concatStringSep concatMap any;
       nameValuePair = name: value: { inherit name value; };
       filterAttrs = pred: set:
         listToAttrs (concatMap (name: let v = set.${name}; in if pred name v then [(nameValuePair name v)] else []) (attrNames set));
@@ -65,7 +65,7 @@
           allOverlays = concatMap (c: c.overlays) (attrValues channels);
 
           overlayNamesList = overlay:
-            attrsNames (overlay null null);
+            attrNames (overlay null null);
         in
           concatMap (o: overlayNamesList o) allOverlays;
 

--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -40,7 +40,7 @@ let
     , builder ? channels.${channelName}.input.lib.nixosSystem
     , modules ? [ ]
     , extraArgs ? { }
-    # These are not part of the module system, so they can be used in `imports` lines without infinite recursion
+      # These are not part of the module system, so they can be used in `imports` lines without infinite recursion
     , specialArgs ? { }
     }: { inherit channelName system output builder modules extraArgs specialArgs; };
 

--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -19,7 +19,7 @@
     extraArgs = sharedExtraArgs;
   }
 
-, packagesBuilder ? null
+, packagesBuilder ? (flake-utils-plus.lib.builder.packagesFromOverlayBuilderConstructor channels)
 , defaultPackageBuilder ? null
 , appsBuilder ? null
 , defaultAppBuilder ? null

--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -19,7 +19,7 @@
     extraArgs = sharedExtraArgs;
   }
 
-, packagesBuilder ? (flake-utils-plus.lib.builder.packagesFromOverlayBuilderConstructor channels)
+, packagesBuilder ? null
 , defaultPackageBuilder ? null
 , appsBuilder ? null
 , defaultAppBuilder ? null


### PR DESCRIPTION
##### depends on https://github.com/numtide/flake-utils/pull/28

##### closes #12 

This is a convenient function that enables sane default sharing of channel overlays:

- It filters on packages per channel, that are also defined in overlays
- therefore, only "custom" stuff that adds potential value to the world is exported

```nix
{
  self.packages."<system>" = {
    # only packages per system who's checks do not trivially fail:
    # - system compatible
    # - a derivation 
    # - meta.broken == false
    # and only packages that are defined by:
    # - some overlay 
    # - on some channel.
    # that includes classical override variants of packages, 
    # as well as new package definitions.
    kakoune = { ... };
  };
}
```

----

checpoint w/o the following:

- cleanup / refactoring
- docstrings
- tackle nixpkgs.lib-is-not-cheap-to-import-issue
- discuss packageBuilder api extension with `channels`