### PR TITLE
imp: ease nixpkgs dependency ban by using divnix/nixpkgs.lib light fork

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,9 @@
   description = "Pure Nix flake utility functions";
 
   inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.lib.url = "https://github.com/divnix/nixpkgs.lib";
 
-  outputs = { self, flake-utils }:
+  outputs = { self, flake-utils, lib }:
     let
       removeSuffix = suffix: str:
         let
@@ -24,7 +25,7 @@
       lib = flake-utils.lib // {
 
         repl = ./repl.nix;
-        systemFlake = import ./systemFlake.nix { flake-utils-plus = self; };
+        systemFlake = import ./systemFlake.nix { flake-utils-plus = self; inherit lib; };
 
         modulesFromList = paths: genAttrs'
           (path: {

--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -1,4 +1,4 @@
-{ flake-utils-plus }:
+{ flake-utils-plus, lib }:
 
 { self
 , defaultSystem ? "x86_64-linux" # will be deprecated soon use hostDefaults.system instead
@@ -134,9 +134,6 @@ let
     }
   );
 
-  mapAttrs' = f: set:
-    builtins.listToAttrs (map (attr: f attr set.${attr}) (builtins.attrNames set));
-
 in
 otherArguments
 
@@ -171,4 +168,4 @@ otherArguments
   # produces attrset in the shape of
   # { nixosConfigurations = {}; darwinConfigurations = {};  ... } 
   # according to profile.output or the default `nixosConfigurations`
-  // mapAttrs' configurationBuilder hosts
+  // lib.mapAttrs' configurationBuilder hosts


### PR DESCRIPTION
This enables us to use latest nixpkgs library functions without the "penalty" and confusion of accessing nixpkgs propper.