### PR TITLE
Improve merging of host arguments and flake outputs

### DIFF
--- a/examples/fully-featured/flake.nix
+++ b/examples/fully-featured/flake.nix
@@ -36,26 +36,21 @@
         system = "aarch64-linux";
         # Default channel to be used for `hosts` defaults to "nixpkgs"
         channelName = "unstable";
-        # Extra arguments to be passed to modules. Merged with sharedExtraArgs on its left hand side and the host's extraArgs on its right hand side
-        extraArgs = { foo = "foo"; };
-        # Default modules to be passed to all hosts. Equivalent to sharedModules (additive merge).
-        modules = [ ];
+        # Extra arguments to be passed to modules. Merged with host's extraArgs
+        extraArgs = { inherit utils inputs; foo = "foo"; };
+        # Default modules to be passed to all hosts.
+        modules = [
+          home-manager.nixosModules.home-manager
+          # Sets sane `nix.*` defaults. Please refer to implementation/readme for more details.
+          utils.nixosModules.saneFlakeDefaults
+          (import ./modules)
+          {
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+          }
+        ];
+
       };
-
-      # Extra arguments to be passed to modules. Defaults to `{ inherit inputs; }`
-      sharedExtraArgs = { inherit utils inputs; };
-
-      # Shared modules/configurations between `hosts`
-      sharedModules = [
-        home-manager.nixosModules.home-manager
-        # Sets sane `nix.*` defaults. Please refer to implementation/readme for more details.
-        utils.nixosModules.saneFlakeDefaults
-        (import ./modules)
-        {
-          home-manager.useGlobalPkgs = true;
-          home-manager.useUserPackages = true;
-        }
-      ];
 
       # Shared overlays between channels, gets applied to all `channels.<name>.input`
       sharedOverlays = [

--- a/examples/fully-featured/flake.nix
+++ b/examples/fully-featured/flake.nix
@@ -133,6 +133,7 @@
       checksBuilder = channels: { check = channels.nixpkgs.runCommandNoCC "test" { } "echo test > $out"; };
 
       # All other values gets passed down to the flake
+      checks.x86_64-linux.merge-with-checksBuilder-test = self.pkgs.x86_64-linux.nixpkgs.hello;
       overlay = import ./overlays;
       abc = 132;
       # etc

--- a/examples/somewhat-realistic/flake.nix
+++ b/examples/somewhat-realistic/flake.nix
@@ -74,7 +74,7 @@
         # This host uses `channels.unstable.{input,overlaysBuilder,config,patches}` attributes instead of `channels.nixpkgs.<...>`
         channelName = "unstable";
 
-        # Host specific configuration. Same as `sharedModules`
+        # Host specific configuration.
         modules = [
           (import ./hosts/Two.nix)
         ];


### PR DESCRIPTION
Create a merge function that can deal with attrsets and lists and use it for:
 - merging host arguments
 - configuration outputs - use it in foldHosts and allow for nixosConfigurations escape hatch

Also fix the issue of packagesBuilder overriding `otherArguments.packages`, by merging each output manually with mkOutput function. Also cleans up the output merging code, its just two strings passed to a function. This doesn't require the merge function.