### PR TITLE
Use nixos modules and lib from patched nixpkgs and allow setting nixpkgs.config values in host modules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,9 @@ jobs:
       - name: Build Rick configuration
         run: cd examples/fully-featured && nix build .#someConfigurations.Rick.config.system.build.toplevel --dry-run
 
+      - name: Build Summer checks
+        run: cd examples/fully-featured && nix build .#checks.x86_64-linux.summerHasUnfreeConfigured && nix build .#checks.x86_64-linux.summerHasPackageOverridesConfigured && nix build .#checks.x86_64-linux.summerHasCustomModuleConfigured
+
       - name: Run `nix flake check`
         run: cd examples/somewhat-realistic && nix flake check --show-trace
 

--- a/examples/fully-featured/configurations/Summer.host.nix
+++ b/examples/fully-featured/configurations/Summer.host.nix
@@ -1,0 +1,6 @@
+{ lib, ... }: {
+  boot.loader.grub.devices = [ "nodev" ];
+  fileSystems."/" = { device = "test"; fsType = "ext4"; };
+  patchedModule.test = lib.patchedFunction "test";
+  nixpkgs.config.packageOverrides = pkgs: { };
+}

--- a/examples/fully-featured/flake.nix
+++ b/examples/fully-featured/flake.nix
@@ -116,6 +116,10 @@
           output = "someConfigurations";
         };
 
+        Summer = {
+          channelName = "unstable";
+          modules = [ ./configurations/Summer.host.nix ];
+        };
       };
 
       # Evaluates to `packages.<system>.attributeKey = "attributeValue"`
@@ -134,7 +138,19 @@
       devShellBuilder = channels: channels.nixpkgs.mkShell { name = "devShell"; };
 
       # Evaluates to `checks.<system>.attributeKey = "attributeValue"`
-      checksBuilder = channels: { check = channels.nixpkgs.runCommandNoCC "test" { } "echo test > $out"; };
+      checksBuilder = channels:
+        let
+          booleanCheck = cond:
+            if cond
+            then channels.nixpkgs.runCommandNoCC "success" { } "echo success > $out"
+            else channels.nixpkgs.runCommandNoCC "failure" { } "exit 1";
+        in
+        {
+          check = channels.nixpkgs.runCommandNoCC "test" { } "echo test > $out";
+          summerHasCustomModuleConfigured = booleanCheck (self.nixosConfigurations.Summer.config.patchedModule.test == "test");
+          summerHasPackageOverridesConfigured = booleanCheck (self.nixosConfigurations.Summer.config.nixpkgs.pkgs.config ? packageOverrides);
+          summerHasUnfreeConfigured = booleanCheck (self.nixosConfigurations.Summer.config.nixpkgs.pkgs.config ? allowUnfree);
+        };
 
       # All other values gets passed down to the flake
       checks.x86_64-linux.merge-with-checksBuilder-test = self.pkgs.x86_64-linux.nixpkgs.hello;

--- a/examples/fully-featured/flake.nix
+++ b/examples/fully-featured/flake.nix
@@ -147,8 +147,11 @@
         in
         {
           check = channels.nixpkgs.runCommandNoCC "test" { } "echo test > $out";
+          # Modules (and lib) from patched nixpkgs are used
           summerHasCustomModuleConfigured = booleanCheck (self.nixosConfigurations.Summer.config.patchedModule.test == "test");
+          # nixpkgs config from host-specific module is used
           summerHasPackageOverridesConfigured = booleanCheck (self.nixosConfigurations.Summer.config.nixpkgs.pkgs.config ? packageOverrides);
+          # nixpkgs config from channel is also used
           summerHasUnfreeConfigured = booleanCheck (self.nixosConfigurations.Summer.config.nixpkgs.pkgs.config ? allowUnfree);
         };
 

--- a/examples/fully-featured/myNixpkgsPatch.patch
+++ b/examples/fully-featured/myNixpkgsPatch.patch
@@ -1,12 +1,38 @@
+diff --git a/lib/default.nix b/lib/default.nix
+index 50320669e28..ff835870e4a 100644
+--- a/lib/default.nix
++++ b/lib/default.nix
+@@ -145,5 +145,7 @@ let
+       nixType imap;
+     inherit (self.versions)
+       splitVersion;
++
++    patchedFunction = x: x;
+   });
+ in lib
+diff --git a/nixos/modules/module-list.nix b/nixos/modules/module-list.nix
+index f72be732216..fbbf9776a6b 100644
+--- a/nixos/modules/module-list.nix
++++ b/nixos/modules/module-list.nix
+@@ -1101,4 +1101,10 @@
+   ./virtualisation/vmware-guest.nix
+   ./virtualisation/xen-dom0.nix
+   ./virtualisation/xe-guest-utilities.nix
++  ({ lib, config, ... }: {
++    options.patchedModule.test = lib.mkOption {
++      default = null;
++      example = "test";
++    };
++  })
+ ]
 diff --git a/pkgs/top-level/all-packages.nix b/pkgs/top-level/all-packages.nix
-index 6dd393492c8..c8456afc28d 100644
+index cdf28b9782c..48ed72bf3c1 100644
 --- a/pkgs/top-level/all-packages.nix
 +++ b/pkgs/top-level/all-packages.nix
-@@ -30930,4 +30930,6 @@ in
+@@ -31025,4 +31025,6 @@ in
    lc3tools = callPackage ../development/tools/lc3tools {};
-
+ 
    zktree = callPackage ../applications/misc/zktree {};
 +
 +  flake-utils-plus-test = callPackage ../applications/misc/hello { };
  }
-

--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -101,13 +101,13 @@ let
                 networking.hostName = hostname;
               })
 
-              (optionalAttrs (options ? nixpkgs) {
+              (if options ? nixpkgs then {
                 nixpkgs.pkgs = import patchedChannel {
                   inherit (host) system;
                   overlays = sharedOverlays ++ (if (channelValue ? overlaysBuilder) then (channelValue.overlaysBuilder pkgs) else [ ]);
                   config = channelsConfig // (channelValue.config or { }) // config.nixpkgs.config;
                 };
-              })
+              } else { _module.args.pkgs = selectedNixpkgs; })
 
               (optionalAttrs (options ? system.configurationRevision) {
                 system.configurationRevision = lib.mkIf (self ? rev) self.rev;

--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -92,6 +92,8 @@ let
     {
       ${host.output}.${hostname} = host.builder {
         inherit (host) system;
+        lib = import (patchedChannel + "/lib");
+        baseModules = import (patchedChannel + "/nixos/modules/module-list.nix");
         modules = [
           ({ pkgs, lib, options, config, ... }: {
             # 'mkMerge` to separate out each part into its own module
@@ -104,7 +106,7 @@ let
               (if options ? nixpkgs then {
                 nixpkgs.pkgs = import patchedChannel {
                   inherit (host) system;
-                  overlays = sharedOverlays ++ (if (channelValue ? overlaysBuilder) then (channelValue.overlaysBuilder pkgs) else [ ]);
+                  overlays = sharedOverlays ++ (if (channelValue ? overlaysBuilder) then (channelValue.overlaysBuilder self.pkgs) else [ ]);
                   config = channelsConfig // (channelValue.config or { }) // config.nixpkgs.config;
                 };
               } else { _module.args.pkgs = selectedNixpkgs; })
@@ -125,7 +127,7 @@ let
             ];
           })
         ] ++ host.modules;
-        specialArgs = host.specialArgs;
+        specialArgs = { modulesPath = builtins.toString (patchedChannel + "/nixos/modules"); } // host.specialArgs;
       };
     }
   );

--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -90,10 +90,8 @@ let
       patchedChannel = patchChannel host.system channelValue.input (channelValue.patches or [ ]);
     in
     {
-      ${host.output}.${hostname} = host.builder {
+      ${host.output}.${hostname} = host.builder ({
         inherit (host) system;
-        lib = import (patchedChannel + "/lib");
-        baseModules = import (patchedChannel + "/nixos/modules/module-list.nix");
         modules = [
           ({ pkgs, lib, options, config, ... }: {
             # 'mkMerge` to separate out each part into its own module
@@ -127,8 +125,12 @@ let
             ];
           })
         ] ++ host.modules;
+        specialArgs = host.specialArgs;
+      } // (optionalAttrs (host.output == "nixosConfigurations") {
+        lib = import (patchedChannel + "/lib");
+        baseModules = import (patchedChannel + "/nixos/modules/module-list.nix");
         specialArgs = { modulesPath = builtins.toString (patchedChannel + "/nixos/modules"); } // host.specialArgs;
-      };
+      }));
     }
   );
 

--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -115,7 +115,7 @@ let
                 networking.hostName = hostname;
               })
 
-              (if options ? nixpkgs then
+              (if options ? nixpkgs.pkgs then
                 {
                   nixpkgs.pkgs =
                     # Make sure we don't import nixpkgs again if not


### PR DESCRIPTION
As far as I can tell, these changes allow patching NixOS and configuring `nixpkgs.config` in the host's modules. I was able to evaluate (and switch to) my nixos config which uses both correctly.

I'll clean this up some more and maybe demonstrate the different possibilities in the fully featured example flake. (That will have to wait until tomorrow though, it's quite late here.)

Fixes #4.