### PR TITLE
fix issue with creating empty outputs

### DIFF
--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -140,11 +140,13 @@ mergeAny otherArguments (
 
         pkgs = mapAttrs importChannel channels;
 
-        mkOutput = output: builder: {
-          ${output} = otherArguments.${output}.${system} or { }
-          // optionalAttrs (args ? ${builder}) (args.${builder} pkgs);
-        };
-
+        mkOutput = output: builder:
+          mergeAny
+            # prevent override of nested outputs in otherArguments
+            (optionalAttrs (otherArguments ? ${output}.${system})
+              { ${output} = otherArguments.${output}.${system}; })
+            (optionalAttrs (args ? ${builder})
+              { ${output} = args.${builder} pkgs; });
       in
       { inherit pkgs; }
       // mkOutput "packages" "packagesBuilder"


### PR DESCRIPTION
fixes this issue:
```
nix-repl> flake.defaultApp
{ aarch64-linux = { ... }; x86_64-linux = { ... }; }

nix-repl> flake.defaultApp.aarch64-linux
{ }
```
All outputs were created regardless if there is a builder passed for it. This wraps both the otherArguments.packages.system and the builder in an `optionalAttrs` and uses `mergeAny` to properly merge the two.