### PR TITLE
Make the example hosts pass assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+examples/*/flake.lock

--- a/examples/fully-featured/configurations/Morty.host.nix
+++ b/examples/fully-featured/configurations/Morty.host.nix
@@ -1,1 +1,3 @@
-{ ... }: { }
+{ ... }: {
+  boot.loader.grub.devices = [ "nodev" ];
+}

--- a/examples/somewhat-realistic/hosts/One.nix
+++ b/examples/somewhat-realistic/hosts/One.nix
@@ -1,1 +1,5 @@
-{ lib, pkgs, config, ... }: { }
+{ lib, pkgs, config, ... }: {
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+  fileSystems."/" = { device = "/dev/disk/by-label/One"; };
+}

--- a/examples/somewhat-realistic/hosts/Two.nix
+++ b/examples/somewhat-realistic/hosts/Two.nix
@@ -1,1 +1,4 @@
-{ lib, pkgs, config, ... }: { }
+{ lib, pkgs, config, ... }: {
+  boot.loader.grub.devices = [ "nodev" ];
+  fileSystems."/".device = "/dev/disk/by-label/Two";
+}


### PR DESCRIPTION
This makes the hosts in the examples properly evaluate by giving them a root filesystem and boot loader. With this, the `somewhat-realistic` example passes `nix flake check` - depends on #38. The hosts of `fully-featured` should now pass, but the flake itself doesn't, because of the IFD that comes with nixpkgs patching.

Also added the flake.lock's in the example flakes to .gitignore. I assume we don't want to commit those, but they have to be there to test things.