### PR TITLE
imp: provide per channel modules paths to make it easy to "backport"

### DIFF
--- a/examples/fully-featured/configurations/Morty.host.nix
+++ b/examples/fully-featured/configurations/Morty.host.nix
@@ -1,4 +1,8 @@
-{ ... }: {
+# auto-special args <channelName>ModulesPath for easy backporting of modules
+{ unstableModulesPath, ... }: {
+
+  imports = [ "${unstableModulesPath}/installer/cd-dvd/installation-cd-minimal-new-kernel.nix" ];
+  disabledModules = [ "installer/cd-dvd/installation-cd-minimal-new-kernel.nix" ];
+
   boot.loader.grub.devices = [ "nodev" ];
-  fileSystems."/" = { device = "test"; fsType = "ext4"; };
 }

--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -93,12 +93,13 @@ let
       lib = selectedNixpkgs.lib;
       # Use nixos modules from patched nixpkgs
       baseModules = import (patchedChannel + "/nixos/modules/module-list.nix");
-      specialArgs = let
-        f = channelName:
-          { "${channelName}ModulesPath" = builtins.toString (channels.${channelName}.input + "/nixos/modules"); };
-      in
+      specialArgs =
+        let
+          f = channelName:
+            { "${channelName}ModulesPath" = builtins.toString (channels.${channelName}.input + "/nixos/modules"); };
+        in
         # Add `<channelName>ModulesPath`s
-        (foldl' (lhs: rhs: lhs // rhs) {} (map f (attrNames channels)))
+        (foldl' (lhs: rhs: lhs // rhs) { } (map f (attrNames channels)))
         # Override `modulesPath` because otherwise imports from there will not use patched nixpkgs
         // { modulesPath = builtins.toString (patchedChannel + "/nixos/modules"); }
         // host.specialArgs;
@@ -158,9 +159,9 @@ let
             ];
           })
         ] ++ host.modules;
-        specialArgs = host.specialArgs;
+        inherit specialArgs;
       } // (optionalAttrs (host.output == "nixosConfigurations") {
-        inherit lib baseModules specialArgs;
+        inherit lib baseModules;
       }));
     }
   );


### PR DESCRIPTION
a module. imports = [ ${myChannelModulesPathk}/installer/...

This allows users to relatively conveniently pull in modules from other channels. The chances of success are mixed depending on the channel distance, but if it works, it's great.