### PR TITLE
General exporter and builderConstructor improvements

### DIFF
--- a/examples/somewhat-realistic/flake.nix
+++ b/examples/somewhat-realistic/flake.nix
@@ -11,10 +11,11 @@
       url = github:nix-community/home-manager/release-20.09;
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    agenix.url = github:ryantm/agenix;
   };
 
 
-  outputs = inputs@{ self, nixpkgs, unstable, utils, nix-darwin, home-manager }:
+  outputs = inputs@{ self, nixpkgs, unstable, utils, nix-darwin, home-manager, agenix }:
     utils.lib.systemFlake {
 
       # `self` and `inputs` arguments are REQUIRED!!!!!!!!!!!!!!
@@ -40,8 +41,9 @@
       channels.nixpkgs.overlaysBuilder = channels: [
         (final: prev: {
           # Overwrites specified packages to be used from unstable channel.
-          inherit (channels.unstable) alacritty ranger jdk15_headless;
+          inherit (channels.unstable) alacritty ranger;
         })
+        agenix.overlay
       ];
 
 
@@ -103,6 +105,13 @@
 
 
 
+      # export overlays automatically for all packages defined in overlaysBuilder of each channel
+      overlays = utils.lib.exporter.overlaysFromChannelsExporter {
+        inherit (self) pkgs inputs;
+      };
+
+      # construct packagesBuilder to export all packages defined in overlays
+      packagesBuilder = utils.lib.builder.packagesFromOverlaysBuilderConstructor self.overlays;
 
       overlay = import ./overlays;
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1618217525,
-        "narHash": "sha256-WGrhVczjXTiswQaoxQ+0PTfbLNeOQM6M36zvLn78AYg=",
+        "lastModified": 1619345332,
+        "narHash": "sha256-qHnQkEp1uklKTpx3MvKtY6xzgcqXDsz5nLilbbuL+3A=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c6169a2772643c4a93a0b5ac1c61e296cba68544",
+        "rev": "2ebf2558e5bf978c7fb8ea927dfaed8fefab2e28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This is some fixups and improvments to the api for the overlaysFromChannelsExporter and packagesFromOverlaysBuilderConstructor. 

Have overlays exporter take `self.pkgs` and `inputs`. The former is so nixpkgs sets are instantiated and the overlay lists are ready. The latter is to auto filter any overlays that were taken from inputs. Its not good to export things that weren't originated in your flake and you don't plan on maintaining.
 
Change packages builderConstructor to just take an attrset of overlays and the builder can then pull out packages defined in overlays from the channels set.