### PR TITLE
embed info in channels and pass host's channel as specialArg

### DIFF
--- a/examples/fully-featured/configurations/Rick.host.nix
+++ b/examples/fully-featured/configurations/Rick.host.nix
@@ -1,1 +1,4 @@
-Morty.host.nix
+{
+  boot.loader.grub.devices = [ "nodev" ];
+  fileSystems."/" = { device = "test"; fsType = "ext4"; };
+}


### PR DESCRIPTION
gives both builders and hosts information about what channel their on. The former is so you can implement channel-specific logic in a builder. In devos we have a extended nixosSystem, so we would want to do `specialArgs.channel.input.lib.nixosSystem`, to ensure we are using the write channel for that host. And modules can do logic to hosts based on what channel the host is on.