### PR TITLE
Option to not export overlay

### DIFF
--- a/examples/somewhat-realistic/flake.nix
+++ b/examples/somewhat-realistic/flake.nix
@@ -43,6 +43,13 @@
           # Overwrites specified packages to be used from unstable channel.
           inherit (channels.unstable) alacritty ranger;
         })
+        (final: prev: {
+          lib = prev.lib.extend (lfinal: lprev: {
+            utils = utils.lib;
+          });
+          # As long as the attribute exists, overlaysFromChannelsExporter won't export it
+          __dontExport = true;
+        })
         agenix.overlay
       ];
 

--- a/overlaysFromChannelsExporter.nix
+++ b/overlaysFromChannelsExporter.nix
@@ -9,6 +9,8 @@ let
 
       inputs: flake inputs to sort out external overlays
 
+      Overlays with an attribute named "__dontExport" will be filtered out.
+
       Returns an attribute set of all packages defined in an overlay by any channel
       intended to be passed to be exported via _self.overlays_. This method of
       sharing has the advantage over _self.packages_, that the user will instantiate
@@ -68,10 +70,11 @@ let
           )
           (overlayNames overlay);
 
-      filterOverlays = channel:
-        filter
-          (overlay: !elem (overlayNames overlay) flattenedInputOverlays)
-          channel.overlays;
+      checkOverlay = overlay:
+        (!elem (overlayNames overlay) flattenedInputOverlays)
+        && (!elem "__dontExport" (overlayNames overlay));
+
+      filterOverlays = channel: filter checkOverlay channel.overlays;
 
     in
     listToAttrs (


### PR DESCRIPTION
This adds the ability to create overlays that aren't exported. You just have to add an attribute called "__dontExport" and the overlaysFromChannelsExporter will filter it out.

As much as I like the auto-exporting overlays, it is kind of frustrating that there is no way out. The other solution is to try and pass the overlay to `inputs` which is needlessly complicated.
```
final: prev: {
  firefox = prev.firefox.override { privacySupport = true; };
  __dontExport = true;
}
```
vs
```
{ pkgs = self.pkgs; inputs = inputs // { internalOverlays.overlays.firefox = _: _: { firefox = null; }; }
```