### PR TITLE
Rename channels to streams

### DIFF
--- a/examples/fully-featured/configurations/Morty.host.nix
+++ b/examples/fully-featured/configurations/Morty.host.nix
@@ -1,4 +1,4 @@
-# auto-special args <channelName>ModulesPath for easy backporting of modules
+# auto-special args <streamName>ModulesPath for easy backporting of modules
 { unstableModulesPath, ... }: {
 
   imports = [ "${unstableModulesPath}/installer/cd-dvd/installation-cd-minimal-new-kernel.nix" ];

--- a/examples/somewhat-realistic/flake.nix
+++ b/examples/somewhat-realistic/flake.nix
@@ -24,24 +24,24 @@
 
 
 
-      # Shared overlays between channels, gets applied to all `channels.<name>.input`
+      # Shared overlays between streams, gets applied to all `streams.<name>.input`
       sharedOverlays = [
         # Overlay imported from `./overlays`. (Defined above)
         self.overlay
       ];
 
-      # Channel definitions. `channels.<name>.{input,overlaysBuilder,config,patches}`
-      channels.nixpkgs.input = nixpkgs;
-      channels.unstable.input = unstable;
+      # Stream definitions. `streams.<name>.{input,overlaysBuilder,config,patches}`
+      streams.nixpkgs.input = nixpkgs;
+      streams.unstable.input = unstable;
 
-      # Default configuration values for `channels.<name>.config = {...}`
-      channelsConfig.allowUnfree = true;
+      # Default configuration values for `streams.<name>.config = {...}`
+      streamsConfig.allowUnfree = true;
 
-      # Channel specific overlays
-      channels.nixpkgs.overlaysBuilder = channels: [
+      # Stream specific overlays
+      streams.nixpkgs.overlaysBuilder = streams: [
         (final: prev: {
-          # Overwrites specified packages to be used from unstable channel.
-          inherit (channels.unstable) alacritty ranger;
+          # Overwrites specified packages to be used from unstable stream.
+          inherit (streams.unstable) alacritty ranger;
         })
         agenix.overlay
       ];
@@ -73,8 +73,8 @@
 
 
       hosts.Bob = {
-        # This host uses `channels.unstable.{input,overlaysBuilder,config,patches}` attributes instead of `channels.nixpkgs.<...>`
-        channelName = "unstable";
+        # This host uses `streams.unstable.{input,overlaysBuilder,config,patches}` attributes instead of `streams.nixpkgs.<...>`
+        streamName = "unstable";
 
         # Host specific configuration.
         modules = [
@@ -92,8 +92,8 @@
 
         system = "x86_64-darwin";
 
-        # This host uses `channels.unstable.{input,overlaysBuilder,config,patches}` attributes instead of `channels.nixpkgs.<...>`
-        channelName = "unstable";
+        # This host uses `streams.unstable.{input,overlaysBuilder,config,patches}` attributes instead of `streams.nixpkgs.<...>`
+        streamName = "unstable";
 
         # Host specific configuration.
         modules = [
@@ -105,8 +105,8 @@
 
 
 
-      # export overlays automatically for all packages defined in overlaysBuilder of each channel
-      overlays = utils.lib.exporter.overlaysFromChannelsExporter {
+      # export overlays automatically for all packages defined in overlaysBuilder of each stream
+      overlays = utils.lib.exporter.overlaysFromStreamsExporter {
         inherit (self) pkgs inputs;
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
       fupArgs = { flake-utils-plus = self; };
       systemFlake = import ./systemFlake.nix fupArgs;
       packagesFromOverlaysBuilderConstructor = import ./packagesFromOverlaysBuilderConstructor.nix fupArgs;
-      overlaysFromChannelsExporter = import ./overlaysFromChannelsExporter.nix fupArgs;
+      overlaysFromStreamsExporter = import ./overlaysFromStreamsExporter.nix fupArgs;
       modulesFromList = import ./moduleFromListExporter.nix fupArgs;
     in
     rec {
@@ -27,7 +27,7 @@
         };
 
         exporter = {
-          inherit overlaysFromChannelsExporter modulesFromList;
+          inherit overlaysFromStreamsExporter modulesFromList;
         };
 
         repl = ./repl.nix;
@@ -42,11 +42,11 @@
             )
             rhs;
 
-        patchChannel = system: channel: patches:
-          if patches == [ ] then channel else
-          (import channel { inherit system; }).pkgs.applyPatches {
-            name = "nixpkgs-patched-${channel.shortRev}";
-            src = channel;
+        patchStream = system: stream: patches:
+          if patches == [ ] then stream else
+          (import stream { inherit system; }).pkgs.applyPatches {
+            name = "nixpkgs-patched-${stream.shortRev}";
+            src = stream;
             patches = patches;
           };
 

--- a/packagesFromOverlaysBuilderConstructor.nix
+++ b/packagesFromOverlaysBuilderConstructor.nix
@@ -5,11 +5,11 @@ let
     let
       # overlays: self.overlays
 
-      packagesFromOverlaysBuilder = channels:
+      packagesFromOverlaysBuilder = streams:
         /**
-          Synopsis: packagesFromOverlaysBuilder _channels_
+          Synopsis: packagesFromOverlaysBuilder _streams_
 
-          channels: builder `channels` argument
+          streams: builder `streams` argument
 
           Returns valid packges that have been defined within an overlay so they
           can be shared via _self.packages_ with the world. This is especially useful
@@ -17,7 +17,7 @@ let
           running from which third parties could benefit.
 
           Steps:
-          1. merge all channels into one nixpkgs attribute set
+          1. merge all streams into one nixpkgs attribute set
           2. collect all overlays' packages' keys into one flat list
           3. pick out each package from the nixpkgs set into one packages set
           $. flatten package set and filter out disallowed packages - by flake check requirements
@@ -44,8 +44,8 @@ let
           nameValuePair = name: value: { inherit name value; };
 
           flattenedPackages =
-            # merge all channels into one package set
-            foldl' (a: b: a // b) { } (attrValues channels);
+            # merge all streams into one package set
+            foldl' (a: b: a // b) { } (attrValues streams);
 
           # flatten all overlays' packages' keys into a single list
           flattenedOverlaysNames =
@@ -67,7 +67,7 @@ let
           # fold list into one attribute set
           exportPackages = foldl' (lhs: rhs: lhs // rhs) { } exportPackagesList;
 
-          system = (head (attrValues channels)).system;
+          system = (head (attrValues streams)).system;
 
         in
         # flatten nested sets with "/" delimiter then drop disallowed packages


### PR DESCRIPTION
I realize this is a bit of a bikeshed, but words matter. After using Nix for 3 years it was enough for me to have an extreme reaction to the word "channels" and their associated updates. I don't think I'm alone in this. In fact, I'd be willing to bet that upstream explicitly removed any mention of the word from flakes for a very good reason. They wanted to make it clear that the painful impurities aligned with channels were a thing of the past.

I was a bit distraught to see that they are trying to be revived here, and so I thought I'd offer up a reasonable alternative. This may not matter much to newer Nix users, but to those who have used Nix stable for a little while, channels are the worst thing Nix has to offer. They break the contract of purity without even being clear about it, leaving you to discover that on your own after a few painful system upgrades.

With that said, I realize that the personal pronound is used extensively throughout this write up, and I understand it is an opinionated change that has 0 impact on usability. Therefore, I wouldn't blame you for rejecting my proposal outright. However, upstream is trying to kill the "channels" nomenclature for a good reason. Please don't keep it on life support.