### PR TITLE
set __dontExport to srcs overlay

### DIFF
--- a/systemFlake.nix
+++ b/systemFlake.nix
@@ -173,7 +173,12 @@ mergeAny otherArguments (
       let
         importChannel = name: value: (import (patchChannel system value.input (value.patches or [ ])) {
           inherit system;
-          overlays = [ (final: prev: { inherit srcs; }) ] ++ sharedOverlays ++ (if (value ? overlaysBuilder) then (value.overlaysBuilder pkgs) else [ ]);
+          overlays = [
+            (final: prev: {
+              __dontExport = true; # in case user uses overlaysFromChannelsExporter, doesn't hurt for others
+              inherit srcs;
+            })
+          ] ++ sharedOverlays ++ (if (value ? overlaysBuilder) then (value.overlaysBuilder pkgs) else [ ]);
           config = channelsConfig // (value.config or { });
         }) // { inherit name; inherit (value) input; };
 


### PR DESCRIPTION
This doesn't hurt in any way, but prevents export for those who use
overlaysFromChannelsExporter