### PR TITLE
systemFlake: make one unified outputsBuilder

### DIFF
--- a/src/systemFlake.nix
+++ b/src/systemFlake.nix
@@ -19,14 +19,21 @@
     extraArgs = sharedExtraArgs;
   }
 
-, outputsBuilder ? channels: { }
+, outputsBuilder ? channels: {
+  packages = packagesBuilder channels;
+  defaultPackage = defaultPackageBuilder channels;
+  apps = appsBuilder channels;
+  defaultApp = defaultAppBuilder channels;
+  devShell = devShellBuilder channels;
+  checks = checksBuilder channels;
+}
 
-, packagesBuilder ? null
-, defaultPackageBuilder ? null
-, appsBuilder ? null
-, defaultAppBuilder ? null
-, devShellBuilder ? null
-, checksBuilder ? null
+, packagesBuilder ? _: { }
+, defaultPackageBuilder ? _: { }
+, appsBuilder ? _: { }
+, defaultAppBuilder ? _: { }
+, devShellBuilder ? _: { }
+, checksBuilder ? _: { }
 , ...
 }@args:
 


### PR DESCRIPTION
replace output-specific builders

This is actually much simpler to implement than the old method. And the code looks waay better.

The hardest part is deprecating the current output-specific builders. I have no idea how to do that. I have tried many things like filtering for builders that return null. Either we end up with the flake just creating all the outputs, or infinite recursion when filtering.

implements/closes #56 