### PR TITLE
Add support for reverse DNS hostname declarations

### DIFF
--- a/lib/systemFlake.nix
+++ b/lib/systemFlake.nix
@@ -32,7 +32,24 @@
 
 let
   inherit (flake-utils-plus.lib) eachSystem patchChannel mergeAny;
-  inherit (builtins) foldl' mapAttrs removeAttrs attrValues attrNames listToAttrs concatMap;
+  inherit (builtins)
+    attrNames
+    attrValues
+    concatMap
+    concatStringsSep
+    elemAt
+    filter
+    foldl'
+    genList
+    head
+    isString
+    length
+    listToAttrs
+    mapAttrs
+    removeAttrs
+    split
+    tail
+    ;
 
   fupOverlay = final: prev: {
     fup-repl = final.writeShellScriptBin "repl" ''
@@ -48,10 +65,10 @@ let
     listToAttrs (concatMap (name: let value = set.${name}; in if pred name value then [ ({ inherit name value; }) ] else [ ]) (attrNames set));
 
   reverseList = xs:
-    let l = builtins.length xs; in builtins.genList (n: builtins.elemAt xs (l - n - 1)) l;
+    let l = length xs; in genList (n: elemAt xs (l - n - 1)) l;
 
   partitionString = sep: s:
-    builtins.filter (v: builtins.isString v) (builtins.split "${sep}" s);
+    filter (v: isString v) (split "${sep}" s);
 
 
   srcs = filterAttrs (_: value: !value ? outputs) inputs;
@@ -104,12 +121,12 @@ let
   configurationBuilder = reverseDnsFqdn: host': (
     let
       dnsLabels = reverseList (partitionString "\\." reverseDnsFqdn);
-      hostname = builtins.head dnsLabels;
+      hostname = head dnsLabels;
       domain = let
-        domainLabels = builtins.tail dnsLabels;
+        domainLabels = tail dnsLabels;
       in
         if domainLabels == [] then (lib.mkDefault null) # null is the networking.domain option's default
-        else builtins.concatStringsSep "." domainLabels;
+        else concatStringsSep "." domainLabels;
 
       selectedNixpkgs = getNixpkgs host;
       host = evalHostArgs (mergeAny hostDefaults host');

--- a/lib/systemFlake.nix
+++ b/lib/systemFlake.nix
@@ -108,7 +108,7 @@ let
       domain = let
         domainLabels = builtins.tail dnsLabels;
       in
-        if domainLabels == [] then null # null is the networking.domain option's default
+        if domainLabels == [] then (lib.mkDefault null) # null is the networking.domain option's default
         else builtins.concatStringsSep "." domainLabels;
 
       selectedNixpkgs = getNixpkgs host;

--- a/lib/systemFlake.nix
+++ b/lib/systemFlake.nix
@@ -118,9 +118,9 @@ let
   getChannels = system: self.pkgs.${system};
   getNixpkgs = host: (getChannels host.system).${host.channelName};
 
-  configurationBuilder = reverseDnsFqdn: host': (
+  configurationBuilder = reverseDomainName': (
     let
-      dnsLabels = reverseList (partitionString "\\." reverseDnsFqdn);
+      dnsLabels = reverseList (partitionString "\\." reverseDomainName);
       hostname = head dnsLabels;
       domain = let
         domainLabels = tail dnsLabels;
@@ -162,7 +162,7 @@ let
       }).config;
     in
     {
-      ${host.output}.${reverseDnsFqdn} = host.builder ({
+      ${host.output}.${reverseDomainName} = host.builder ({
         inherit (host) system;
         modules = [
           ({ pkgs, lib, options, config, ... }: {

--- a/tests/hosts-config/flake.nix
+++ b/tests/hosts-config/flake.nix
@@ -39,6 +39,8 @@
 
       hosts.Plain = { };
 
+      hosts."com.example.myhost" = { };
+
       hosts.WithFakeBuilder = {
         builder = args: { fakeBuilder = "fakeBuilder"; };
       };
@@ -69,6 +71,12 @@
           let
             plainHost = self.someConfigurations.Plain;
             plainHostPkgs = plainHost.config.nixpkgs.pkgs;
+            plainHostName = plainHost.config.networking.hostName;
+            plainHostDomain = plainHost.config.networking.domain;
+
+            reverseDnsHost = self.someConfigurations."com.example.myhost";
+            reverseDnsHostName = reverseDnsHost.config.networking.hostName;
+            reverseDnsHostDomain = reverseDnsHost.config.networking.domain;
 
             customizedHost = self.darwinConfigurations.Customized;
             customizedHostPkgs = customizedHost.config.nixpkgs.pkgs;
@@ -86,6 +94,10 @@
 
             specialArgs_valid_1 = hasKey plainHost.config.lib "sharedSpecialArg";
 
+            hostName_valid_1 = isEqual plainHostName "Plain";
+
+            domain_valid_1 = isEqual plainHostDomain null;
+
 
             # System with overwritten hostDefaults
             system_valid_2 = isEqual customizedHostPkgs.system "x86_64-darwin";
@@ -97,6 +109,12 @@
             extraArgs_valid_2 = hasKey customizedHost.config.lib "hostExtraArg";
 
             specialArgs_valid_2 = hasKey customizedHost.config.lib "hostSpecialArg";
+
+
+            # Hostname and Domain set from reverse DNS name
+            hostName_valid_3 = isEqual reverseDnsHostName "myhost";
+
+            domain_valid_3 = isEqual reverseDnsHostDomain "example.com";
 
 
             # Eval fakeBuilder

--- a/tests/testing-utils.nix
+++ b/tests/testing-utils.nix
@@ -7,13 +7,16 @@
     fileSystems."/" = { device = "test"; fsType = "ext4"; };
   };
 
-  isEqual = a: b:
+  isEqual = a: b: let
+    stringifyNull = s:
+      if s == null then "-null-" else s;
+  in
     if a == b
-    then nixpkgs.runCommandNoCC "success-${a}-IS-EQUAL-${b}" { } "echo success > $out"
-    else nixpkgs.runCommandNoCC "falure-${a}-IS-NOT-EQUAL-${b}" { } "exit 1";
+    then nixpkgs.runCommandNoCC "success-${stringifyNull a}-IS-EQUAL-${stringifyNull b}" { } "echo success > $out"
+    else nixpkgs.runCommandNoCC "faliure-${stringifyNull a}-IS-NOT-EQUAL-${stringifyNull b}" { } "exit 1";
 
   hasKey = attrset: key:
     if attrset ? ${key}
     then nixpkgs.runCommandNoCC "success-${key}-exists-in-attrset" { } "echo success > $out"
-    else nixpkgs.runCommandNoCC "falure-key-${key}-does-not-exist-in-attrset" { } "exit 1";
+    else nixpkgs.runCommandNoCC "faliure-key-${key}-does-not-exist-in-attrset" { } "exit 1";
 }


### PR DESCRIPTION
Implements naming `nixosConfigurations` like so:

`"com.example.myhost"` and automatically sets the `networking.domain` option if declared this way.

`nixosConfigurations."com.example.myhost"`


I chose reverese dns notation a) for proper grouping (e.g. in a repl) and b) since at this stage they alias a host's config, not precisely a host's IP, like normal DNS would.