### PR TITLE
fix: don't append overlays manually when passing pkgs

### DIFF
--- a/lib/systemFlake.nix
+++ b/lib/systemFlake.nix
@@ -190,7 +190,7 @@ let
                       import patchedChannel
                         {
                           inherit (host) system;
-                          overlays = selectedNixpkgs.overlays ++ hostConfig.nixpkgs.overlays;
+                          overlays = selectedNixpkgs.overlays;
                           config = selectedNixpkgs.config // config.nixpkgs.config;
                         } // { inherit (selectedNixpkgs) name input; };
                 }


### PR DESCRIPTION
overlays get appended by nixpkgs module
creates problems with overlays that apply patches, since they try to get applied twice.