### PR TITLE
da/learn names from module meta

### DIFF
--- a/lib/modulesFromList.nix
+++ b/lib/modulesFromList.nix
@@ -1,17 +1,14 @@
 { flake-utils-plus }:
 let
 
-  modulesFromListExporter = args:
+  modulesFromListExporter = paths:
     /**
       Synopsis: modulesFromListExporter _paths_
 
-      paths:    [ <path> <path> ] or { paths = [ ]; _import = <function>; }
+      paths:    [ <path> <path> ]
 
       Returns an attribute set of modules from a list of paths by converting
       the path's basename into the attribute key.
-
-      Optionally, an attrset can be passed containing `paths` and `_import`
-      to control how paths get imported
 
       Example:
 
@@ -25,11 +22,6 @@ let
       **/
 
     let
-
-      # To allow for the default to just pass a list
-      # or pass an attrset with `paths` and `_import`
-      paths = args.paths or args;
-      _import = args._import or import;
 
       removeSuffix = suffix: str:
         let
@@ -47,8 +39,8 @@ let
 
     genAttrs'
       (path: {
-        name = removeSuffix ".toml" (removeSuffix ".nix" (baseNameOf path));
-        value = _import path;
+        name = removeSuffix ".nix" (baseNameOf path);
+        value = import path;
       })
       paths;
 

--- a/lib/modulesFromList.nix
+++ b/lib/modulesFromList.nix
@@ -1,22 +1,22 @@
 { flake-utils-plus }:
 let
 
-  modulesFromListExporter = paths:
+  modulesFromListExporter = args:
     /**
-      Synopsis: modulesFromListExporter _paths_
+      Synopsis: modulesFromListExporter _paths or modules_
 
-      paths:    [ <path> <path> ]
+      paths:    [ <path> <module> ]
 
-      Returns an attribute set of modules from a list of paths by converting
-      the path's basename into the attribute key.
+      Returns an attribute set of modules from a list of paths or modules by converting
+      the path's basename / the module's _file attribute's basename into the attribute key.
 
       Example:
 
-      paths:    [ ./path/to/moduleA.nix ./path/to/moduleBfolder ]
+      paths:    [ ./path/to/moduleA.nix { _file = ./path/to/moduleBfolder; ... } ]
 
       {
       moduleA = import ./path/to/moduleA.nix;
-      moduleBfolder = import ./path/to/moduleBfolder;
+      moduleBfolder = { _file = ./path/to/moduleBfolder; ... }
       }
 
       **/
@@ -35,14 +35,40 @@ let
 
       genAttrs' = func: values: builtins.listToAttrs (map func values);
 
+      hasFileAttr = o: builtins.hasAttr "_file" o;
+      peek = f: f (builtins.functionArgs f);
+
     in
 
     genAttrs'
-      (path: {
-        name = removeSuffix ".nix" (baseNameOf path);
-        value = import path;
-      })
-      paths;
+      (arg:
+
+        # a regular path to be imported
+        if builtins.isPath arg then
+          {
+            name = removeSuffix ".nix" (baseNameOf arg);
+            value = import arg;
+          }
+
+        # a module function with a _file attr
+        else if ((builtins.isFunction arg) && (hasFileAttr (peek args))) then
+          {
+            name = removeSuffix ".toml" (removeSuffix ".nix" (baseNameOf (peek arg)._file));
+            value = arg;
+          }
+
+        # a module with a _file attr
+        else if (hasFileAttr arg) then
+          {
+            name = removeSuffix ".toml" (removeSuffix ".nix" (baseNameOf arg._file));
+            value = arg;
+          }
+
+        # panic: something else
+        else
+          builtins.throw "either pass a path or a module with _file key to modulesFromListExporter"
+      )
+      args;
 
 in
 modulesFromListExporter


### PR DESCRIPTION
A laid back import has a disadvantage:

Downstream users that choose to import at the code entrypoint have to carry those like a callback all the way trough the code-path to `fup`. So no unified import at that entry-point is possible.

With this change, users can design code that imports any module as soon as they wish as long as it honors the ubiquitous `_file` key convention.

- Collateral downstream benefit of construing compatible modules: error reporting becomes more user friendly (no `<unnokwn-file>` anymore).


---

- Revert "modulesFromList: allow for import customization"
- modulesFromList: infer names from paths or modules's _file attr
