### PR TITLE
Add mkDefault to extra-options

### DIFF
--- a/lib/repl.nix
+++ b/lib/repl.nix
@@ -29,4 +29,4 @@ in
 // (flake.nixosConfigurations or { })
 // flake.nixosConfigurations.${hostname} or { }
 // nixpkgsOutput
-  // { loadFlake = path: getFlake (toString path);}
+  // { loadFlake = path: getFlake (toString path); }

--- a/lib/systemFlake.nix
+++ b/lib/systemFlake.nix
@@ -196,7 +196,7 @@ let
               })
 
               (optionalAttrs (options ? nix.extraOptions) {
-                nix.extraOptions = lib.mkDefault "experimental-features = nix-command ca-references flakes";
+                nix.extraOptions = "extra-experimental-features = nix-command ca-references flakes";
               })
 
               {

--- a/lib/systemFlake.nix
+++ b/lib/systemFlake.nix
@@ -196,7 +196,7 @@ let
               })
 
               (optionalAttrs (options ? nix.extraOptions) {
-                nix.extraOptions = "experimental-features = nix-command ca-references flakes";
+                nix.extraOptions = lib.mkDefault "experimental-features = nix-command ca-references flakes";
               })
 
               {


### PR DESCRIPTION
Resolve #76 #77
I left `ca-references` in since I am not sure why it is there and I am afraid to remove it. 
If I recall correctly at some point `ca-references` were required for flakes for some reason thus was erroring out for me. Maybe it was a bug or some odd config. Not sure.