### PR TITLE
Preparing for release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,6 @@ jobs:
       - uses: actions/checkout@v2.3.4
       - uses: cachix/install-nix-action@v13
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
           install_url: https://github.com/numtide/nix-unstable-installer/releases/download/nix-2.4pre20210604_8e6ee1b/install
           extra_nix_config: experimental-features = nix-command flakes
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Main flake-utils-plus features (Attributes visible from `flake.nix`):
 - [`lib.exportModules [ ./a.nix ./b.nix ]`](./lib/exportModules.nix) - Generates module attribute which look like this `{ a = import ./a.nix; b = import ./b.nix; }`.
 - [`lib.exportOverlays channels`](./lib/exportOverlays.nix) - Exports all overlays from channels as an appropriately namespaced attribute set. Users can instantiate with their nixpkgs version.
 - [`lib.exportPackages self.overlays channels`](./lib/exportPackages.nix) - Similar to the overlay generator, but outputs them as packages for the platforms defined in `meta.platforms`. Unlike overlays, these packages are consistent across flakes allowing them to be cached.
-- `pkgs.fup-repl` - Adds a kick-ass repl. Usage:
+- `pkgs.fup-repl` - A package that adds a kick-ass repl. Usage:
     - `$ repl` - Loads your system repl into scope as well as `pkgs` and `lib` from `nixpkgs` input.
     - `$ repl /path/to/flake.nix` - Same as above only that it loads specified flake.
 

--- a/devShell.nix
+++ b/devShell.nix
@@ -1,17 +1,17 @@
 { system ? builtins.currentSystem }:
 let
   # nixpkgs / devshell is only used for development. Don't add it to the flake.lock.
-  nixpkgsGitRev = "246502ae2d5ca9def252abe0ce6363a0f08382a7";
-  devshellGitRev = "1f4fb67b662b65fa7cfe696fc003fcc1e8f7cc36";
+  nixpkgsGitRev = "82d05e980543e1703cbfd3b5ccd1fdcd4b0f1f00";
+  devshellGitRev = "26f25a12265f030917358a9632cd600b51af1d97";
 
   nixpkgsSrc = fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/${nixpkgsGitRev}.tar.gz";
-    sha256 = "sha256-cuCj8CfBrVlEYQM2jfD3psh2jV/sR5HACYkC74WR9KE=";
+    sha256 = "02yqgivv8kxksv7n6vmh22qxprlfjh4rfkgf98w46nssq5ahdb1q";
   };
 
   devshellSrc = fetchTarball {
     url = "https://github.com/numtide/devshell/archive/${devshellGitRev}.tar.gz";
-    sha256 = "03258pq60nppq39571bjxqn75h3rn25bdlrx04k75v20n77xfs5c";
+    sha256 = "sha256:0f6fph5gahm2bmzd399mba6b0h6wp6i1v3gryfmgwp0as7mwqpj7";
   };
 
   pkgs = import nixpkgsSrc { inherit system; };

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1629481132,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
         "type": "github"
       },
       "original": {

--- a/lib/mkFlake.nix
+++ b/lib/mkFlake.nix
@@ -42,6 +42,7 @@ let
     reverseList
     ;
   inherit (builtins)
+    pathExists
     attrNames
     attrValues
     concatMap
@@ -222,7 +223,9 @@ mergeAny otherArguments (
         filterAttrs = pred: set:
           listToAttrs (concatMap (name: let value = set.${name}; in if pred name value then [ ({ inherit name value; }) ] else [ ]) (attrNames set));
 
-        channelFlakes = filterAttrs (_: value: value ? legacyPackages) inputs;
+        # Little hack, we make sure that `legacyPackages` contains `nix` to make sure that we are dealing with nixpkgs.
+        # For some odd reason `devshell` contains `legacyPackages` out put as well
+        channelFlakes = filterAttrs (_: value: value.legacyPackages.x86_64-linux ? nix) inputs;
         channelsFromFlakes = mapAttrs (name: input: { inherit input; }) channelFlakes;
 
         importChannel = name: value: (import (patchChannel system value.input (value.patches or [ ])) {

--- a/lib/mkFlake.nix
+++ b/lib/mkFlake.nix
@@ -225,7 +225,7 @@ mergeAny otherArguments (
 
         # Little hack, we make sure that `legacyPackages` contains `nix` to make sure that we are dealing with nixpkgs.
         # For some odd reason `devshell` contains `legacyPackages` out put as well
-        channelFlakes = filterAttrs (_: value: value.legacyPackages.x86_64-linux ? nix) inputs;
+        channelFlakes = filterAttrs (_: value: value ? legacyPackages && value.legacyPackages.x86_64-linux ? nix) inputs;
         channelsFromFlakes = mapAttrs (name: input: { inherit input; }) channelFlakes;
 
         importChannel = name: value: (import (patchChannel system value.input (value.patches or [ ])) {


### PR DESCRIPTION
Also, does this more or less summarize everything in staging?

```md
Improvements:
- Now overlays receive `srcs` option by default which represents Github repositories from inputs
- `channels.*.input` is no longer required. By default it gets autogenerated from `inputs`

Deprecations:
- Updated fup-repl implementation, now it is a package and can load flake references by path.
- Replaced xyzBuilder(s) with `outputsBuilder`.
- Replaced `saneFlakeDefaults` nixosModule with `nix.generateRegistryFromInputs` option (set it to `true` to enable it)

Implemented multiple exporters: (Please see examples on the project page!)
- `lib.exportModules` - Helper that builds attribute set of modules from paths.
- `lib.exportOverlays` - Helper that builds namespaced attribute set of overlays.
- `lib.exportPackages` - Helper that outputs packages depending on `meta.platforms`

```