### PR TITLE
fix too much magic with inputs

### DIFF
--- a/examples/exporters/flake.nix
+++ b/examples/exporters/flake.nix
@@ -16,6 +16,7 @@
       inherit self inputs;
 
       # Channel specific overlays. Overlays `coreutils` from `unstable` channel.
+      channels.unstable = {};
       channels.nixpkgs.overlaysBuilder = channels: [
         (final: prev: { inherit (channels.unstable) ranger; })
       ];

--- a/examples/home-manager+nur+neovim/flake.nix
+++ b/examples/home-manager+nur+neovim/flake.nix
@@ -26,6 +26,7 @@
 
 
       channelsConfig.allowUnfree = true;
+      channels.nixpkgs = {};
 
       sharedOverlays = [
         nur.overlay

--- a/examples/minimal-multichannel/flake.nix
+++ b/examples/minimal-multichannel/flake.nix
@@ -16,6 +16,8 @@
       # Channels are automatically generated from nixpkgs inputs
       # e.g the inputs which contain `legacyPackages` attribute are used.
       channelsConfig.allowUnfree = true;
+      channels.nixpkgs = {};
+      channels.unstable = {};
 
 
       # Modules shared between all hosts


### PR DESCRIPTION
- update flake-utils for filterPackages fixups
- imp: provide per channel modules paths to make it easy to "backport"
- fix test
- overlays exporter: use pkgs and inputs use pkgs to collect overlays from each channel, since user only passes overlaysBuilder for each channel. Also filter out any overlays defined in inputs
- packagesBuilder constructor: take set of overlays This is intended to be self.overlays which allows a cleaner api to pass what overlays should be collected and used to create packages export
- examples: demonstrate updated exporters/builders specifically packagesFromOverlaysBuilderConstructor and overlaysFromChannelsExporter
- pass channel to hosts as channel specialArg add name and input to each channel
- fix Rick host build by making it separate
- add simple devshell & align dev and ci environment
- fixups / cleanups devshell
- prevent infinite recursion in overlays exporter sometimes the inputs argument might contain "self", so drop that if it does. This is just for safety, it usually won't contain self
- export mergeAny in public lib
- Add 'srcs' to overlays
- Add ability to create non-exported overlays with the __dontExport property
- always use self.pkgs instead of channels this allows systemFlake to be called multiple times without having to pass `channels` each time. As long as it just uses self.pkgs, nixpkgs will only get evaluated once and all systemFlake calls use the same channels set
- set __dontExport to srcs overlay This doesn't hurt in any way, but prevents export for those who use overlaysFromChannelsExporter
- flake: update flake-utils input includes filterPackages improvements
- Work on tests and restructoring (#54)
- fromOverlays: opt-in for exporting sub-systems sub-systems are not great for flakes ecosystems and this prevents exporting overriden sub-systems from nixpkgs
- Add replace xyzBuilder with unified 'outputsBuilder'
- Add derivation tests
- Tests cleanup
- Add build-all and check-all commands
- modulesFromList: allow for import customization and allow .toml files
- Rename lib to src
- #60: nixUnstable -> nixFlakes
- #63: Replace saneFlakeDefaults with nix.generateRegistryFromInputs option
- Fix few repl.nix usecases
- #61: Implement 'channels.<name>.input' autogen if not defined
- Revert "#60: nixUnstable -> nixFlakes"
- Fix nix.extraOptions
- Work on repl.nix
- Add fup-repl
- Add support for reverse DNS hostname declarations
- fix: if domain is not set, pass a default only to remain overridable.
- fix/style: pull used builtins in scope
- fix: naming
- fixup
- don't append overlays manually when passing pkgs overlays get appended by nixpkgs module
- systemFlake: set __dontExport for fupOverlay
- Update testing-utils.nix derivation names
- bump flake-utils: incorporate new shiny check-utils
- Revert "modulesFromList: allow for import customization"
- modulesFromList: infer names from paths or modules's _file attr
- fixup! modulesFromList: infer names from paths or modules's _file attr
- Update dependencies + implement check-utils
- Seperate repl overlay and implement help menu
- Make repl find system flake path more dynamically
- Make 'self' flake to always exist as part of the registry
- Fix repl paths checking
- Allow repl open even if flake was not found
- 71: Fix repl reproducability
- Add loadFlake function
- Add mkDefault to extra-options
- Use extra-experimental-features instead of experimental-features
- Fix formatting
- examples: add comments
- imp: allow arguments for devshell checks
- imp: make output dynamic according to outputsBuilder
- README: update documentation to future lib
- Update README.md
- Fix Github Actions
- Fix build scripts
- Post rebase fixes
- Post rebase fixes
- move functions to lib/internal-functions.nix
- flake.nix: change functions to new names
- flake.nix: move internal-functions to own attrset
- properly call internal lib
- fix formatting
- rename export{Overlays,Packages}
- fix: exportModules can be a function or attrs
- fix: reverse rakeLeaves implementation for exportModules
- Fix modulesFromList deprecation
- Update devshell
- Update flake-utils
- Update README.md
- Tweak repl implementation
- Update README.md
- Update README.md
- Update channels selection filter logic
- Update channels selection filter logic
- Remove nix_path option from workflow file
- Revert auto-channel detection that produced irrecoverable edge-cases
