### PR TITLE
Revert auto-channel detection that produced irrecoverable edge-cases

### DIFF
--- a/examples/exporters/flake.nix
+++ b/examples/exporters/flake.nix
@@ -16,6 +16,7 @@
       inherit self inputs;
 
       # Channel specific overlays. Overlays `coreutils` from `unstable` channel.
+      channels.unstable = {};
       channels.nixpkgs.overlaysBuilder = channels: [
         (final: prev: { inherit (channels.unstable) ranger; })
       ];

--- a/examples/home-manager+nur+neovim/flake.nix
+++ b/examples/home-manager+nur+neovim/flake.nix
@@ -26,6 +26,7 @@
 
 
       channelsConfig.allowUnfree = true;
+      channels.nixpkgs = {};
 
       sharedOverlays = [
         nur.overlay

--- a/examples/minimal-multichannel/flake.nix
+++ b/examples/minimal-multichannel/flake.nix
@@ -16,6 +16,8 @@
       # Channels are automatically generated from nixpkgs inputs
       # e.g the inputs which contain `legacyPackages` attribute are used.
       channelsConfig.allowUnfree = true;
+      channels.nixpkgs = {};
+      channels.unstable = {};
 
 
       # Modules shared between all hosts


### PR DESCRIPTION
In more advanced usage scenarios, the guarantees of this code path
are never strong enough and the error produced is non-recoverable.

Sorry to lovers of "automagic".
