### PR TITLE
remove ca-references on nix2.5pre

### DIFF
--- a/lib/mkFlake.nix
+++ b/lib/mkFlake.nix
@@ -171,7 +171,7 @@ let
               })
 
               (optionalAttrs (options ? nix.extraOptions) {
-                nix.extraOptions = "extra-experimental-features = nix-command ca-references flakes";
+                nix.extraOptions = "extra-experimental-features = nix-command ${lib.optionalString (!lib.versionAtLeast config.nix.package.version "2.5pre") "ca-references"} flakes";
               })
 
               {
@@ -237,4 +237,3 @@ mergeAny otherArguments (
   # according to profile.output or the default `nixosConfigurations`
   // foldl' mergeAny { } (attrValues (mapAttrs configurationBuilder hosts))
 )
-


### PR DESCRIPTION
to avoid this issue output: `warning: unknown experimental feature 'ca-references'`