### PR TITLE
Add function, genPkgOverlay, to create an overlay for an input's package

### DIFF
--- a/examples/home-manager+nur+neovim/flake.nix
+++ b/examples/home-manager+nur+neovim/flake.nix
@@ -10,7 +10,6 @@
 
     neovim = {
       url = github:neovim/neovim?dir=contrib;
-      inputs.nixpkgs.follows = "nixpkgs";
     };
 
     home-manager = {
@@ -30,7 +29,8 @@
       sharedOverlays = [
         nur.overlay
         self.overlay
-        neovim.overlay
+        # Use `neovim.packages.${system}.neovim`, for reproducibility with neovim's flake
+        (utils.lib.genPkgOverlay neovim "neovim")
       ];
 
 

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,7 @@
       exportModules = import ./lib/exportModules.nix fupArgs;
       exportOverlays = import ./lib/exportOverlays.nix fupArgs;
       exportPackages = import ./lib/exportPackages.nix fupArgs;
+      genPkgOverlay = import ./lib/genPkgOverlay.nix;
       internal-functions = import ./lib/internal-functions.nix;
       overlay = import ./lib/overlay.nix;
     in
@@ -23,7 +24,7 @@
       devShell.x86_64-linux = import ./devShell.nix { system = "x86_64-linux"; };
 
       lib = flake-utils.lib // {
-        inherit mkFlake exportModules exportOverlays exportPackages;
+        inherit mkFlake exportModules exportOverlays exportPackages genPkgOverlay;
 
         # DO NOT USE - subject to change without notice
         internal = internal-functions;

--- a/lib/genPkgOverlay.nix
+++ b/lib/genPkgOverlay.nix
@@ -1,0 +1,25 @@
+/**
+  Synopsis: generate an overlay that includes a package from an input
+
+  input: a flake input that has a `packages` or `defaultPackage` output
+  pname: the name of the package to include.
+  If the package isn't in the `packages` output,
+  `defaultPackage` will be used, otherwise an
+  error will be thrown when trying to use the package.
+
+  Example:
+  flake-utils-plus.mkFlake {
+  sharedOverlays = [
+  (flake-utils-plus.lib.genPkgOverlay neovim "neovim")
+  # To use agenix's `defaultPackage`
+  (flake-utils-plus.lib.genPkgOverlay agenix "")
+  ];
+  }
+*/
+input: pname:
+# Returning an overlay
+final: prev: {
+  __dontExport = true;
+  ${pname} = input.packages.${prev.system}.${pname}
+    or input.defaultPackage.${prev.system};
+}


### PR DESCRIPTION
This is a function to make it easier to add packages from flakes that don't have an `overlay` output. And its also useful if you prefer using the the exported package from a flake instead of the overlay. There are some good reasons for doing this: cache hits, reproducibility, overlay is failing with your channel.

I was thinking of making this an api argument for fup or digga, but I think a lib function is the cleanest way of doing this. I can't think of a good name, so suggestions are welcome.