### PR TITLE
Export `autoGenFromInputs` module for `nix-darwin`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
       inherit overlay;
 
       nixosModules.autoGenFromInputs = import ./lib/options.nix;
+      darwinModules.autoGenFromInputs = import ./lib/options.nix;
 
       devShell.x86_64-linux = import ./devShell.nix { system = "x86_64-linux"; };
 


### PR DESCRIPTION
I recently realized that there's little difference between NixOS,
nix-darwin and home-manager's module systems, so modules should work
across them as long as the options are implemented.