### PR TITLE
fix: check for system when looking for nixpkgs channels

### DIFF
--- a/lib/mkFlake.nix
+++ b/lib/mkFlake.nix
@@ -205,7 +205,7 @@ mergeAny otherArguments (
 
         # Little hack, we make sure that `legacyPackages` contains `nix` to make sure that we are dealing with nixpkgs.
         # For some odd reason `devshell` contains `legacyPackages` out put as well
-        channelFlakes = filterAttrs (_: value: value ? legacyPackages && value.legacyPackages.x86_64-linux ? nix) inputs;
+        channelFlakes = filterAttrs (_: value: value ? legacyPackages && value.legacyPackages ? x86_64-linux && value.legacyPackages.x86_64-linux ? nix) inputs;
         channelsFromFlakes = mapAttrs (name: input: { inherit input; }) channelFlakes;
 
         importChannel = name: value: (import (patchChannel system value.input (value.patches or [ ])) {


### PR DESCRIPTION
`flake-utils-plus` currently has a bug to do with finding NixPkgs channels. It checks
for `legacyPackages.x86_64-linux.nix` on each flake input to determine if it is NixPkgs.
This typically works, but some flakes may define `legacyPackages` which can cause issues
if they omit the system used for this check (among other issues).
The fix adds an additional check to
ensure that the entire attribute path `legacyPackages.x86_64-linux.nix` exists rather
than expecting `x86_64-linux` to always be defined. This avoids the error that would prevent
integrating tools like [agenix](https://github.com/ryantm/agenix/tree/main) in a flake that
uses `flake-utils-plus`.

See a reproduction here: https://github.com/jakehamilton/fup-channels-bug
