### PR TITLE
fix passing nixpkgs.config if nixpkgs.pkgs.config is present

### DIFF
--- a/lib/mkFlake.nix
+++ b/lib/mkFlake.nix
@@ -146,7 +146,6 @@ let
 
               (if options ? nixpkgs.pkgs then
                 {
-                  nixpkgs.config = selectedNixpkgs.config;
                   nixpkgs.pkgs =
                     # Make sure we don't import nixpkgs again if not
                     # necessary. We can't use `config.nixpkgs.config`


### PR DESCRIPTION
Fix gytis-ivaskevicius/flake-utils-plus#136, caused by NixOS/nixpkgs#257458