### PR TITLE
fix: Override option nixpkgs.config to avoid failed assertion

### DIFF
--- a/lib/mkFlake.nix
+++ b/lib/mkFlake.nix
@@ -157,8 +157,9 @@ let
                         {
                           inherit (host) system;
                           overlays = selectedNixpkgs.overlays;
-                          config = selectedNixpkgs.config // config.nixpkgs.config;
+                          config = selectedNixpkgs.config // hostConfig.nixpkgs.config;
                         } // { inherit (selectedNixpkgs) name input; };
+                  nixpkgs.config = lib.mkForce { };
                 }
               else { })
 


### PR DESCRIPTION
Fixes #142 

Note that other modules could conceivably be affected if they read the value of `config.nixpkgs.config`, but I find that exceedingly unlikely.