### PR TITLE
chore: Remove unused bindings

### DIFF
--- a/devShell.nix
+++ b/devShell.nix
@@ -18,7 +18,6 @@ let
   devshell = import devshellSrc { inherit system; };
 
   withCategory = category: attrset: attrset // { inherit category; };
-  util = withCategory "utils";
 
   rootDir = "$PRJ_ROOT";
 

--- a/lib/exportPackages.nix
+++ b/lib/exportPackages.nix
@@ -78,7 +78,7 @@ let
           # fold list into one attribute set
           exportPackages = foldl' (lhs: rhs: lhs // rhs) { } exportPackagesList;
 
-          system = (head (attrValues channels)).system;
+          inherit ((head (attrValues channels))) system;
 
         in
         # flatten nested sets with "/" delimiter then drop disallowed packages

--- a/lib/internal-functions.nix
+++ b/lib/internal-functions.nix
@@ -1,7 +1,7 @@
 with builtins;
 rec {
   filterAttrs = pred: set:
-    listToAttrs (concatMap (name: let value = set.${name}; in if pred name value then [ ({ inherit name value; }) ] else [ ]) (attrNames set));
+    listToAttrs (concatMap (name: let value = set.${name}; in if pred name value then [{ inherit name value; }] else [ ]) (attrNames set));
 
   /* Generate an attribute set by mapping a function over a list of
     attribute names.
@@ -40,7 +40,7 @@ rec {
     => [ "nix" "json" "yaml" ]
   */
   partitionString = sep: s:
-    filter (v: isString v) (split "${sep}" s);
+    filter isString (split "${sep}" s);
 
   # Returns the type of a path: regular (for file), symlink, or directory
   pathType = p: getAttr (baseNameOf p) (readDir (dirOf p));

--- a/lib/mkFlake.nix
+++ b/lib/mkFlake.nix
@@ -28,22 +28,15 @@ let
     reverseList
     ;
   inherit (builtins)
-    pathExists
     attrNames
     attrValues
     concatMap
     concatStringsSep
-    elemAt
-    filter
     foldl'
-    genList
     head
-    isString
-    length
     listToAttrs
     mapAttrs
     removeAttrs
-    split
     tail
     ;
 

--- a/lib/mkFlake.nix
+++ b/lib/mkFlake.nix
@@ -96,7 +96,7 @@ let
 
       /* nixos specific arguments */
       # Use lib from patched nixpkgs
-      lib = selectedNixpkgs.lib;
+      inherit (selectedNixpkgs) lib;
       # Use nixos modules from patched nixpkgs
       baseModules = import (patchedChannel + "/nixos/modules/module-list.nix");
       nixosSpecialArgs =
@@ -149,7 +149,7 @@ let
                       import patchedChannel
                         {
                           inherit (host) system;
-                          overlays = selectedNixpkgs.overlays;
+                          inherit (selectedNixpkgs) overlays;
                           config = selectedNixpkgs.config // hostConfig.nixpkgs.config;
                         } // { inherit (selectedNixpkgs) name input; };
                   nixpkgs.config = lib.mkForce { };
@@ -194,7 +194,7 @@ mergeAny otherArguments (
     (system:
       let
         filterAttrs = pred: set:
-          listToAttrs (concatMap (name: let value = set.${name}; in if pred name value then [ ({ inherit name value; }) ] else [ ]) (attrNames set));
+          listToAttrs (concatMap (name: let value = set.${name}; in if pred name value then [{ inherit name value; }] else [ ]) (attrNames set));
 
         # Little hack, we make sure that `legacyPackages` contains `nix` to make sure that we are dealing with nixpkgs.
         # For some odd reason `devshell` contains `legacyPackages` out put as well

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -18,10 +18,10 @@ let
   cfg = config.nix;
 in
 {
-  options = {
-    nix.generateNixPathFromInputs = mkFalseOption "Generate NIX_PATH from available inputs.";
-    nix.generateRegistryFromInputs = mkFalseOption "Generate Nix registry from available inputs.";
-    nix.linkInputs = mkFalseOption "Symlink inputs to /etc/nix/inputs.";
+  options.nix = {
+    generateNixPathFromInputs = mkFalseOption "Generate NIX_PATH from available inputs.";
+    generateRegistryFromInputs = mkFalseOption "Generate Nix registry from available inputs.";
+    linkInputs = mkFalseOption "Symlink inputs to /etc/nix/inputs.";
   };
 
   config = {

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -1,7 +1,7 @@
 { lib, config, inputs, ... }:
 
 let
-  inherit (lib) mkIf filterAttrs mapAttrsToList mapAttrs' mkOption types;
+  inherit (lib) mkIf filterAttrs mapAttrs' mkOption types;
   mkFalseOption = description: mkOption {
     inherit description;
     default = false;


### PR DESCRIPTION
Hi Gytis and others :wave:

I was wondering whether I could make `flake-utils-plus` load flake parts modules and/or vice versa, and found these unused bindings with https://github.com/oxalica/nil, so I figured I'd help out a tiny bit with this little cleanup first.

Flake parts is intended to be a mostly unopinionated common interface that helps with interoperability between pieces of Nix logic people write and publish for reuse. Users of `flake-utils-plus` benefit from this, as it makes arbitrary other flake-based functionality easy to import, so that they don't have to cobble up custom glue code to merge the flake outputs and then still be stuck with two frameworks that don't actually share things like packages very well.
I'll set it up so that it doesn't add a flake inputs dependency on flake-parts.