### PR TITLE
fix(overlays): overlays applied in modules were not effective in nix-darwin

### DIFF
--- a/devShell.nix
+++ b/devShell.nix
@@ -78,6 +78,8 @@ devshell.mkShell {
     (test "derivation-outputs")
     (test "hosts-config")
     (test "overlays-flow")
+    (test "nix-darwin-overlays-flow")
+    (test "nix-darwin-overlays-flow-plus-config")
     (test "all" // { command = "check-derivation-outputs && check-hosts-config && check-overlays-flow"; })
 
     (dry-nixos-build "minimal-multichannel" "Hostname1")

--- a/lib/mkFlake.nix
+++ b/lib/mkFlake.nix
@@ -179,7 +179,6 @@ let
         inherit specialArgs;
       } // (optionalAttrs (host.output == "darwinConfigurations") {
         inherit inputs;
-        pkgs = selectedNixpkgs;
       }) // (optionalAttrs (host.output == "nixosConfigurations") {
         inherit lib baseModules;
         specialArgs = nixosSpecialArgs // specialArgs;

--- a/tests/nix-darwin-overlays-flow-plus-config/flake.nix
+++ b/tests/nix-darwin-overlays-flow-plus-config/flake.nix
@@ -1,0 +1,111 @@
+{
+  inputs.utils.url = path:../../;
+  inputs.nix-darwin.url = github:nix-darwin/nix-darwin;
+  inputs.nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
+
+  outputs = inputs@{ self, nixpkgs, utils, nix-darwin }:
+    utils.lib.mkFlake {
+      inherit self inputs;
+      supportedSystems = [ "aarch64-darwin" ];
+      channels.nixpkgs.input = nixpkgs;
+
+
+
+      #################
+      ### Test Data ###
+      #################
+
+      channelsConfig = {
+        allowUnfree = true;
+      };
+
+      # Applied to all Channels
+      sharedOverlays = [
+        (final: prev: {
+          fromSharedOverlays = prev.hello;
+        })
+      ];
+
+      # Applied only to `nixpkgs` channel
+      channels.nixpkgs.overlaysBuilder = channels: [
+        (final: prev: {
+          fromChannelSpecific = prev.hello;
+        })
+      ];
+
+
+      # Hosts
+      hostDefaults = {
+        system = "aarch64-darwin";
+        output = "darwinConfigurations";
+        builder = nix-darwin.lib.darwinSystem;
+        modules = [
+          ({ inputs, ... }: {
+            system = {
+              stateVersion = 5;
+              configurationRevision = (inputs.nix-darwin.rev or inputs.nix-darwin.dirtyRev or null);
+            };
+          })
+          {
+            nixpkgs.overlays = [
+              (final: prev: { fromHostConfig = prev.hello; })
+            ];
+          }
+          {
+            nixpkgs.config.allowBroken = true;
+          }
+          {
+            nixpkgs.overlays =
+              [
+                (final: prev:
+                  if prev.config.allowUnfree then {
+                    allowUnfreeApplied = prev.hello;
+                  } else { })
+              ];
+          }
+          {
+            nixpkgs.overlays =
+              [
+                (final: prev:
+                  if prev.config.allowBroken then {
+                    allowBrokenApplied = prev.hello;
+                  } else { })
+              ];
+          }
+        ];
+      };
+
+      hosts.ExistingPkgsFlow = { };
+
+
+      ######################
+      ### Test execution ###
+      ######################
+
+      outputsBuilder = channels: {
+        checks =
+          let
+            inherit (utils.lib.check-utils channels.nixpkgs) hasKey;
+            existingPkgsFlow = self.darwinConfigurations.ExistingPkgsFlow.pkgs;
+          in
+          {
+
+            # ExistingPkgsFlow
+            sharedOverlays_Applied_1 = hasKey existingPkgsFlow "fromSharedOverlays";
+
+            channelSpecific_Applied_1 = hasKey existingPkgsFlow "fromChannelSpecific";
+
+            hostConfig_Applied_1 = hasKey existingPkgsFlow "fromHostConfig";
+
+            contains_srcs_1 = hasKey existingPkgsFlow "srcs";
+
+            allowsUnfree_Applied_1 = hasKey existingPkgsFlow "allowUnfreeApplied";
+
+            allowsBroken_Applied_1 = hasKey existingPkgsFlow "allowBrokenApplied";
+
+          };
+      };
+
+    };
+}
+

--- a/tests/nix-darwin-overlays-flow/flake.nix
+++ b/tests/nix-darwin-overlays-flow/flake.nix
@@ -1,0 +1,82 @@
+{
+  inputs.utils.url = path:../../;
+  inputs.nix-darwin.url = github:nix-darwin/nix-darwin;
+  inputs.nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
+
+  outputs = inputs@{ self, nixpkgs, utils, nix-darwin }:
+    utils.lib.mkFlake {
+      inherit self inputs;
+      supportedSystems = [ "aarch64-darwin" ];
+      channels.nixpkgs.input = nixpkgs;
+
+
+
+      #################
+      ### Test Data ###
+      #################
+
+      # Applied to all Channels
+      sharedOverlays = [
+        (final: prev: {
+          fromSharedOverlays = prev.hello;
+        })
+      ];
+
+      # Applied only to `nixpkgs` channel
+      channels.nixpkgs.overlaysBuilder = channels: [
+        (final: prev: {
+          fromChannelSpecific = prev.hello;
+        })
+      ];
+
+
+      # Hosts
+      hostDefaults = {
+        system = "aarch64-darwin";
+        output = "darwinConfigurations";
+        builder = nix-darwin.lib.darwinSystem;
+        modules = [
+          ({ inputs, ... }: {
+            system = {
+              stateVersion = 5;
+              configurationRevision = (inputs.nix-darwin.rev or inputs.nix-darwin.dirtyRev or null);
+            };
+          })
+          {
+            nixpkgs.overlays = [
+              (final: prev: { fromHostConfig = prev.hello; })
+            ];
+          }
+        ];
+      };
+
+      hosts.ExistingPkgsFlow = { };
+
+
+      ######################
+      ### Test execution ###
+      ######################
+
+      outputsBuilder = channels: {
+        checks =
+          let
+            inherit (utils.lib.check-utils channels.nixpkgs) hasKey;
+            existingPkgsFlow = self.darwinConfigurations.ExistingPkgsFlow.pkgs;
+          in
+          {
+
+            # ExistingPkgsFlow
+            sharedOverlays_Applied_1 = hasKey existingPkgsFlow "fromSharedOverlays";
+
+            channelSpecific_Applied_1 = hasKey existingPkgsFlow "fromChannelSpecific";
+
+            hostConfig_Applied_1 = hasKey existingPkgsFlow "fromHostConfig";
+
+            contains_srcs_1 = hasKey existingPkgsFlow "srcs";
+
+          };
+      };
+
+    };
+}
+


### PR DESCRIPTION
I have a module that needs to install an overlay to work. 

I have something like this:
```nix
{ pkgs, inputs, ... }: {
  imports = [
    {
       nixpkgs.overlays = [
         inputs.vscode-marketplace.default.overlay
       ]
    }
  ];

  config = {
    ...
    extensions = [
      # vscode-marketplace would not exist although we installed
      # the overlay above
      pkgs.vscode-marketplace.extension-bla-bla
      ...
    ]
  }
}
```

I found the `overlays-flow` test that seem to work fine without `nix-darwin`, but with `nix-darwin` the `overlays` applied through `nixpkgs.overlays` get broken. It seems the cause of the bug is pushing `pkgs` attribute to `extraArgs`, which seem to prevent `nix-darwin` from being able to modify the value for subsequent modules.

I've covered this with tests. There seem to be some differences in how `pkgs` is initialized depending on whether `config` is overridden or not, so I've added two tests that I copied over from `overlays-flow`. One modifies the config and the other doesn't.
