### PR TITLE
examples/flake-parts-module: FUP abstractions as a flake-parts module (POC)

### DIFF
--- a/examples/flake-parts-module/README.md
+++ b/examples/flake-parts-module/README.md
@@ -11,7 +11,7 @@ can work seamlessly within the flake-parts ecosystem.
 
 | FUP feature | flake-parts module equivalent |
 |---|---|
-| `channels` | `fup.channels` — declare multiple nixpkgs inputs with per-channel config, overlays, source patches |
+| `channels` | `fup.channels` — declare multiple nixpkgs inputs with per-channel config and overlays |
 | `sharedOverlays` | `fup.sharedOverlays` — overlays applied to every channel |
 | `hosts` / `hostDefaults` | `fup.hosts` — reverse-DNS hostnames, builder dispatch (NixOS/darwin) |
 | `nix.generateRegistryFromInputs` | `fup.autoRegistry` / `fup.autoNixPath` |

--- a/examples/flake-parts-module/README.md
+++ b/examples/flake-parts-module/README.md
@@ -1,0 +1,45 @@
+# flake-parts module example
+
+This example demonstrates how FUP's core abstractions (multi-channel management,
+declarative hosts, overlay propagation, auto-registry) can be expressed as a
+**composable flake-parts module**.
+
+It is a proof-of-concept showing that the same design that makes FUP ergonomic
+can work seamlessly within the flake-parts ecosystem.
+
+## Features demonstrated
+
+| FUP feature | flake-parts module equivalent |
+|---|---|
+| `channels` | `fup.channels` — declare multiple nixpkgs inputs with per-channel config, overlays, source patches |
+| `sharedOverlays` | `fup.sharedOverlays` — overlays applied to every channel |
+| `hosts` / `hostDefaults` | `fup.hosts` — reverse-DNS hostnames, builder dispatch (NixOS/darwin) |
+| `nix.generateRegistryFromInputs` | `fup.autoRegistry` / `fup.autoNixPath` |
+| `nix.generateNixPathFromInputs` | same |
+| — | `fupChannels` perSystem argument for devShells/packages |
+
+## Architectural note
+
+FUP's `mkFlake` is monolithic — one function generates all outputs. This module
+uses flake-parts' module system: options are declared, config is computed, and
+modules compose. This avoids two design debts in the original:
+
+1. **No double-eval**: FUP evaluates the entire NixOS config twice to sniff
+   `nixpkgs.config`. This module evaluates nixpkgs once per (system, channel)
+   pair at the flake level, cached via `channelCache`.
+
+2. **No srcs side-channel**: FUP injects non-flake inputs into nixpkgs via an
+   overlay. This module doesn't — inputs stay in their proper scope.
+
+## Usage
+
+```bash
+nix flake show github:gytis-ivaskevicius/flake-utils-plus#examples-flake-parts-module
+```
+
+## Try it locally
+
+```bash
+cd examples/flake-parts-module
+nix flake show
+```

--- a/examples/flake-parts-module/example-module.nix
+++ b/examples/flake-parts-module/example-module.nix
@@ -1,0 +1,3 @@
+{ lib, pkgs, ... }: {
+  environment.systemPackages = [ pkgs.hello ];
+}

--- a/examples/flake-parts-module/flake.nix
+++ b/examples/flake-parts-module/flake.nix
@@ -1,0 +1,101 @@
+{
+  description = "FUP concepts as a composable flake-parts module";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-24.11";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+
+    # Uncomment to test darwin:
+    # nix-darwin.url = "github:LnL7/nix-darwin";
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+
+      # Import the FUP-as-flake-parts-module
+      imports = [ ./fup-module.nix ];
+
+      # ====================================================================
+      # FUP-style configuration via flake-parts module options
+      # ====================================================================
+      fup = {
+        # 1. MULTI-CHANNEL — declare multiple nixpkgs versions
+        channels = {
+          nixpkgs = {
+            input = inputs.nixpkgs;
+            config.allowUnfree = false;
+            # Per-channel overlays: receives all channel pkgs for cross-refs
+            overlaysBuilder = allPkgs: [
+              (final: prev: {
+                inherit (allPkgs.stable) hello;
+              })
+            ];
+          };
+
+          stable = {
+            input = inputs.nixpkgs-stable;
+            config.allowUnfree = true;
+          };
+        };
+
+        # 2. SHARED OVERLAYS — applied to every channel
+        sharedOverlays = [
+          (final: prev: {
+            hello-fup = final.hello.overrideAttrs (old: {
+              pname = "${old.pname}-fup";
+            });
+          })
+        ];
+
+        # 3. HOST ABSTRACTION — declarative machines
+        hostDefaults = {
+          system = "x86_64-linux";
+          channelName = "nixpkgs";
+        };
+
+        hosts = {
+          # Reverse-DNS: "com.example.server" → hostname: "server", domain: "example.com"
+          "com.example.server" = {
+            system = "x86_64-linux";
+            modules = [
+              ({ pkgs, ... }: {
+                environment.systemPackages = [ pkgs.hello-fup ];
+              })
+            ];
+          };
+
+          "com.example.laptop" = {
+            system = "x86_64-linux";
+            channelName = "stable";
+          };
+        };
+
+        # 4. AUTO-REGISTRY
+        autoRegistry = true;
+        autoNixPath = true;
+      };
+
+      # ── Everything else works normally alongside fup options ──
+      perSystem = { pkgs, fupChannels, system, ... }: {
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [ nix nixpkgs-fmt ];
+          shellHook = ''
+            echo "Channels available: ${toString (builtins.attrNames fupChannels)}"
+          '';
+        };
+
+        packages.hello-from-stable = fupChannels.stable.hello;
+
+        apps.show-channels = {
+          type = "app";
+          program = toString (pkgs.writeShellScript "show-channels" ''
+            echo "Channel versions for ${system}:"
+            echo "  nixpkgs: ${fupChannels.nixpkgs.lib.version or "N/A"}"
+            echo "  stable:  ${fupChannels.stable.lib.version or "N/A"}"
+          '');
+        };
+      };
+    };
+}

--- a/examples/flake-parts-module/flake.nix
+++ b/examples/flake-parts-module/flake.nix
@@ -75,6 +75,15 @@
         # 4. AUTO-REGISTRY
         autoRegistry = true;
         autoNixPath = true;
+
+        # 5. EXPORT OVERLAYS — flake.overlays."nixpkgs/hello-fup", etc.
+        exportOverlays = true;
+
+        # 6. EXPORT PACKAGES — flake.packages.<system>.hello-fup, etc.
+        exportPackages = true;
+
+        # 7. EXPORT MODULES — flake.nixosModules.example-module
+        nixosModules = [ ./example-module.nix ];
       };
 
       # ── Everything else works normally alongside fup options ──

--- a/examples/flake-parts-module/fup-module.nix
+++ b/examples/flake-parts-module/fup-module.nix
@@ -3,14 +3,14 @@
 let
   inherit (lib)
     types mkOption mkIf mkDefault
-    mapAttrs filterAttrs optionalAttrs
-    foldl' recursiveUpdate
-    concatStringsSep head tail;
+    mapAttrs mapAttrsToList filterAttrs optionalAttrs
+    foldl' recursiveUpdate unique elem
+    concatStringsSep head tail removeSuffix;
 
   inherit (builtins)
     attrNames attrValues listToAttrs removeAttrs
     concatMap isString filter genList elemAt
-    length toString;
+    length toString baseNameOf;
 
   # ---------------------------------------------------------------------------
   # Helpers
@@ -168,6 +168,34 @@ in
       default = false;
       description = "Generate nix.nixPath from flake inputs (added to host modules).";
     };
+
+    exportOverlays = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Export per-channel overlays as namespaced flake overlays.
+        Each package defined in a channel's overlays is exported as
+        "channelName/packageName" under flake.overlays.
+      '';
+    };
+
+    exportPackages = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Export overlay-defined packages as flake packages per system.
+        Only derivations whose meta.platforms includes the current system are exported.
+      '';
+    };
+
+    nixosModules = mkOption {
+      type = types.listOf types.path;
+      default = [ ];
+      description = ''
+        Paths to NixOS modules to export as flake.nixosModules,
+        keyed by their basename (without .nix extension).
+      '';
+    };
   };
 
   config =
@@ -236,6 +264,46 @@ in
 
       # Convenience accessor
       getChannelsFor = system: channelCache.${system} or { };
+
+      # -----------------------------------------------------------------------
+      # Overlay introspection helpers
+      # -----------------------------------------------------------------------
+
+      # A representative system for overlay name extraction (any will do).
+      oneSystem = head config.systems;
+
+      # Return attribute names defined by an overlay, using real evaluated pkgs
+      # (passed as both final and prev — values are wrong, but keys are correct).
+      # Returns [] if the overlay fails to evaluate (e.g. cross-channel refs).
+      overlayAttrNames = channelName: overlay:
+        let
+          pkgs = channelCache.${oneSystem}.${channelName} or { };
+          result = builtins.tryEval (attrNames (overlay pkgs pkgs));
+        in
+        filter (n: n != "__dontExport") (if result.success then result.value else [ ]);
+
+      # All overlay-defined package names across all channels (deduplicated).
+      allOverlayPackageNames = system:
+        let chanPkgs = getChannelsFor system; in
+        unique (concatMap (channelName:
+          let pkgs = chanPkgs.${channelName} or { }; in
+          concatMap (overlay: overlayAttrNames channelName overlay) (pkgs.overlays or [ ])
+        ) (attrNames allChannels));
+
+      # Build the overlays attrset: "channelName/pkgName" -> single-attr overlay.
+      computedExportedOverlays =
+        listToAttrs (concatMap (channelName:
+          let
+            chanPkgs = channelCache.${oneSystem}.${channelName} or null;
+            overlays = if chanPkgs != null then chanPkgs.overlays or [ ] else [ ];
+          in
+          concatMap (overlay:
+            map (pkgName: {
+              name = "${channelName}/${pkgName}";
+              value = final: prev: { ${pkgName} = (overlay final prev).${pkgName}; };
+            }) (overlayAttrNames channelName overlay)
+          ) overlays
+        ) (attrNames allChannels));
 
       # -----------------------------------------------------------------------
       # Host building
@@ -314,12 +382,42 @@ in
       # -----------------------------------------------------------------------
       perSystem = { system, ... }: {
         config._module.args.fupChannels = getChannelsFor system;
+
+        config.packages = mkIf (cfg.exportPackages && allChannels != { }) (
+          let
+            chanPkgs = getChannelsFor system;
+            mergedPkgs = foldl' recursiveUpdate { } (attrValues chanPkgs);
+            pkgNames = allOverlayPackageNames system;
+            isExportable = name:
+              let pkg = mergedPkgs.${name} or null; in
+              pkg != null
+              && pkg ? type && pkg.type == "derivation"
+              && (!(pkg ? meta && pkg.meta ? platforms)
+                  || elem system pkg.meta.platforms);
+          in
+          listToAttrs (
+            concatMap (name:
+              if isExportable name
+              then [{ inherit name; value = mergedPkgs.${name}; }]
+              else [ ]
+            ) pkgNames
+          )
+        );
       };
 
       # -----------------------------------------------------------------------
-      # Flake-level: build host configuration sets
+      # Flake-level: build host configuration sets, exported overlays, modules
       # -----------------------------------------------------------------------
-      flake = foldl' recursiveUpdate { }
-        (mapAttrsToList buildOneHost cfg.hosts);
+      flake = foldl' recursiveUpdate { } (
+        (mapAttrsToList buildOneHost cfg.hosts)
+        ++ lib.optional (cfg.exportOverlays && allChannels != { } && config.systems != [ ])
+          { overlays = computedExportedOverlays; }
+        ++ lib.optional (cfg.nixosModules != [ ]) {
+          nixosModules = listToAttrs (map (path: {
+            name = removeSuffix ".nix" (baseNameOf (toString path));
+            value = import path;
+          }) cfg.nixosModules);
+        }
+      );
     };
 }

--- a/examples/flake-parts-module/fup-module.nix
+++ b/examples/flake-parts-module/fup-module.nix
@@ -16,20 +16,6 @@ let
   # Helpers
   # ---------------------------------------------------------------------------
 
-  # Apply patches to a nixpkgs source tree. Same approach as FUP.
-  patchNixpkgs = system: channelInput: patches:
-    if patches == [ ] then channelInput
-    else
-      let
-        bootstrapPkgs = import channelInput { inherit system; };
-        patchedSrc = bootstrapPkgs.applyPatches {
-          name = "nixpkgs-patched";
-          src = channelInput;
-          inherit patches;
-        };
-      in
-      toString patchedSrc;
-
   # Detect whether an input looks like nixpkgs (has x86_64-linux nix).
   isNixpkgsLike = name: value:
     value ? legacyPackages
@@ -109,11 +95,6 @@ in
               Function: (allChannelPkgs) -> [ overlay ].
               Receives every channel's evaluated pkgs for cross-channel references.
             '';
-          };
-          patches = mkOption {
-            type = types.listOf types.path;
-            default = [ ];
-            description = "Patches to apply to nixpkgs source before importing.";
           };
         };
       });
@@ -236,10 +217,7 @@ in
                 allPkgs = mapAttrs
                   (name: ch:
                     let
-                      src =
-                        if ch.patches == [ ] then ch.input
-                        else patchNixpkgs system ch.input ch.patches;
-                      pkgs = import src {
+                      pkgs = import ch.input {
                         inherit system;
                         overlays = cfg.sharedOverlays
                           ++ (if ch.overlaysBuilder != null
@@ -248,7 +226,7 @@ in
                         config = cfg.channelsConfig // ch.config;
                       };
                     in
-                    pkgs // { inherit (ch) input patches; }
+                    pkgs // { inherit (ch) input; }
                   )
                   allChannels;
               in

--- a/examples/flake-parts-module/fup-module.nix
+++ b/examples/flake-parts-module/fup-module.nix
@@ -1,0 +1,347 @@
+{ config, lib, flake-parts-lib, self, inputs, ... }:
+
+let
+  inherit (lib)
+    types mkOption mkIf mkDefault
+    mapAttrs filterAttrs optionalAttrs
+    foldl' recursiveUpdate
+    concatStringsSep head tail;
+
+  inherit (builtins)
+    attrNames attrValues listToAttrs removeAttrs
+    concatMap isString filter genList elemAt
+    length toString;
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  # Apply patches to a nixpkgs source tree. Same approach as FUP.
+  patchNixpkgs = system: channelInput: patches:
+    if patches == [ ] then channelInput
+    else
+      let
+        bootstrapPkgs = import channelInput { inherit system; };
+        patchedSrc = bootstrapPkgs.applyPatches {
+          name = "nixpkgs-patched";
+          src = channelInput;
+          inherit patches;
+        };
+      in
+      toString patchedSrc;
+
+  # Detect whether an input looks like nixpkgs (has x86_64-linux nix).
+  isNixpkgsLike = name: value:
+    value ? legacyPackages
+    && value.legacyPackages ? x86_64-linux
+    && value.legacyPackages.x86_64-linux ? nix;
+
+  # Reverse a list.
+  reverseList = xs:
+    let l = length xs; in genList (n: elemAt xs (l - n - 1)) l;
+
+  # Partition a dotted name into segments.
+  splitLabels = dotted:
+    filter isString (builtins.split "\\." dotted);
+
+  # Extract hostname from reverse-DNS (e.g. "com.example.mybox" -> "mybox").
+  hostnameFromReverseDNS = reverseDomain:
+    head (reverseList (splitLabels reverseDomain));
+
+  # Extract domain from reverse-DNS (e.g. "com.example.mybox" -> "example.com").
+  domainFromReverseDNS = reverseDomain:
+    let
+      labels = reverseList (splitLabels reverseDomain);
+      domainLabels = tail labels;
+    in
+    if domainLabels == [ ] then null
+    else concatStringsSep "." domainLabels;
+
+  # Generate a NixOS module fragment for registry / nixPath.
+  mkRegistryModule = { autoRegistry, autoNixPath }:
+    { lib, ... }:
+    let cfg = autoRegistry; nixPathCfg = autoNixPath; in
+    {
+      config.nix = {
+        registry = mkIf cfg
+          (mapAttrs (name: v: { flake = v; })
+            (filterAttrs (_: v: v ? outputs) inputs));
+        nixPath = mkIf nixPathCfg
+          (mkDefault [ "/etc/nix/inputs" ]);
+      };
+    };
+
+  # Merge a raw host declaration with hostDefaults.
+  resolveHost = name: host: hostDefaults:
+    let d = hostDefaults; in
+    {
+      system = if host.system != "" then host.system else d.system;
+      channelName = if host.channelName != "" then host.channelName else d.channelName;
+      output = if host.output != "" then host.output else d.output;
+      modules = host.modules;
+      extraArgs = host.extraArgs;
+      specialArgs = host.specialArgs;
+      builder =
+        if host.builder != null then host.builder
+        else d.builder;
+    };
+
+in
+{
+  options.fup = {
+    channels = mkOption {
+      description = "Nixpkgs channels. Each key is a channel name.";
+      type = types.lazyAttrsOf (types.submodule {
+        options = {
+          input = mkOption {
+            type = types.raw;
+            description = "The nixpkgs flake input.";
+          };
+          config = mkOption {
+            type = types.attrsOf types.unspecified;
+            default = { };
+            description = "nixpkgs config (allowUnfree, etc.).";
+          };
+          overlaysBuilder = mkOption {
+            type = types.nullOr (types.functionTo (types.listOf types.raw));
+            default = null;
+            description = ''
+              Function: (allChannelPkgs) -> [ overlay ].
+              Receives every channel's evaluated pkgs for cross-channel references.
+            '';
+          };
+          patches = mkOption {
+            type = types.listOf types.path;
+            default = [ ];
+            description = "Patches to apply to nixpkgs source before importing.";
+          };
+        };
+      });
+      default = { };
+      example = {
+        nixpkgs = { input = "nixpkgs"; };
+        unstable = { input = "nixpkgs-unstable"; unstable.config.allowUnfree = true; };
+      };
+    };
+
+    sharedOverlays = mkOption {
+      type = types.listOf types.raw;
+      default = [ ];
+      description = "Overlays applied to every channel.";
+    };
+
+    channelsConfig = mkOption {
+      type = types.attrsOf types.unspecified;
+      default = { };
+      description = "Default nixpkgs config for all channels.";
+    };
+
+    hostDefaults = mkOption {
+      description = "Default host configuration applied to every host.";
+      type = types.submodule {
+        options = {
+          system = mkOption { type = types.str; default = "x86_64-linux"; };
+          channelName = mkOption { type = types.str; default = "nixpkgs"; };
+          output = mkOption { type = types.str; default = "nixosConfigurations"; };
+          builder = mkOption { type = types.nullOr types.raw; default = null; };
+          modules = mkOption { type = types.listOf types.raw; default = [ ]; };
+          extraArgs = mkOption { type = types.attrsOf types.unspecified; default = { }; };
+          specialArgs = mkOption { type = types.attrsOf types.unspecified; default = { }; };
+        };
+      };
+      default = { };
+    };
+
+    hosts = mkOption {
+      description = ''
+        Machine declarations keyed by reverse-DNS name, e.g. "com.example.mybox".
+      '';
+      type = types.lazyAttrsOf (types.submodule {
+        options = {
+          system = mkOption { type = types.str; default = ""; };
+          channelName = mkOption { type = types.str; default = ""; };
+          output = mkOption { type = types.str; default = ""; };
+          builder = mkOption { type = types.nullOr types.raw; default = null; };
+          modules = mkOption { type = types.listOf types.raw; default = [ ]; };
+          extraArgs = mkOption { type = types.attrsOf types.unspecified; default = { }; };
+          specialArgs = mkOption { type = types.attrsOf types.unspecified; default = { }; };
+        };
+      });
+      default = { };
+    };
+
+    autoDetectChannels = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Auto-detect nixpkgs-like inputs as channels when `channels` is empty.";
+    };
+
+    autoRegistry = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Generate nix.registry from flake inputs (added to host modules).";
+    };
+
+    autoNixPath = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Generate nix.nixPath from flake inputs (added to host modules).";
+    };
+  };
+
+  config =
+    let
+      cfg = config.fup;
+
+      # -----------------------------------------------------------------------
+      # Channel resolution
+      # -----------------------------------------------------------------------
+      detectedChannels =
+        if cfg.autoDetectChannels && cfg.channels == { }
+        then
+          mapAttrs (name: input: { inherit input; })
+            (filterAttrs isNixpkgsLike inputs)
+        else { };
+
+      allChannels = cfg.channels // detectedChannels;
+
+      # -----------------------------------------------------------------------
+      # System → channel pkgs cache, evaluated at the flake level.
+      #
+      # Strategy: evaluate nixpkgs once per (system, channel) pair, cache the
+      # result, and use it for both host building and perSystem injection.
+      #
+      # This avoids the double-eval hack in FUP's main mkFlake (which evaluates
+      # NixOS config twice to sniff nixpkgs.config), and avoids cross-module-
+      # system data transfer issues inside flake-parts.
+      # -----------------------------------------------------------------------
+      resolvedHosts = mapAttrs (name: host: resolveHost name host cfg.hostDefaults) cfg.hosts;
+
+      # Systems we actually need channels for
+      neededSystems = lib.unique (
+        (map (h: h.system) (attrValues resolvedHosts))
+        ++ config.systems
+      );
+
+      # system -> { channelName -> pkgs }
+      # Lazily evaluated: a system's channels are only imported when accessed.
+      channelCache = listToAttrs (map
+        (system: {
+          name = system;
+          value =
+            if allChannels == { } then { }
+            else
+              let
+                # allPkgs is lazy — overlaysBuilder receives unevaluated thunks
+                allPkgs = mapAttrs
+                  (name: ch:
+                    let
+                      src =
+                        if ch.patches == [ ] then ch.input
+                        else patchNixpkgs system ch.input ch.patches;
+                      pkgs = import src {
+                        inherit system;
+                        overlays = cfg.sharedOverlays
+                          ++ (if ch.overlaysBuilder != null
+                        then ch.overlaysBuilder allPkgs
+                        else [ ]);
+                        config = cfg.channelsConfig // ch.config;
+                      };
+                    in
+                    pkgs // { inherit (ch) input patches; }
+                  )
+                  allChannels;
+              in
+              allPkgs;
+        })
+        neededSystems);
+
+      # Convenience accessor
+      getChannelsFor = system: channelCache.${system} or { };
+
+      # -----------------------------------------------------------------------
+      # Host building
+      # -----------------------------------------------------------------------
+      registryModule = mkRegistryModule {
+        autoRegistry = cfg.autoRegistry;
+        autoNixPath = cfg.autoNixPath;
+      };
+
+      # Build one host declaration into flake output attributes
+      buildOneHost = name: hostRaw:
+        let
+          h = resolveHost name hostRaw cfg.hostDefaults;
+
+          # Grab channel pkgs for this host's system
+          chanPkgsSet = getChannelsFor h.system;
+          chanPkgs =
+            if allChannels == { } then
+            # No channels configured — fallback: hosts must provide their own
+            # pkgs through nixpkgs.pkgs in a module
+              null
+            else
+              chanPkgsSet.${h.channelName} or
+                (throw "fup: host '${name}' references channel '${h.channelName}' which is not available on '${h.system}'. Available: ${toString (attrNames chanPkgsSet)}");
+
+          hostname = hostnameFromReverseDNS name;
+          domain = domainFromReverseDNS name;
+
+          # Wiring module: injects pkgs, hostname, domain, revision
+          wiringModule = { lib, options, ... }: {
+            networking.hostName = lib.mkDefault hostname;
+            networking.domain = lib.mkIf (domain != null) (lib.mkDefault domain);
+            system.configurationRevision = lib.mkIf (self ? rev && options ? system.configurationRevision) self.rev;
+          } // optionalAttrs (chanPkgs != null) {
+            nixpkgs.pkgs = chanPkgs;
+          };
+
+          baseModules = h.modules ++ [ wiringModule ]
+            ++ optionalAttrs (cfg.autoRegistry || cfg.autoNixPath) [ registryModule ];
+
+          # Resolve builder function
+          builder =
+            if h.builder != null then h.builder
+            else if h.output == "darwinConfigurations" then
+              throw "fup: host '${name}' has output 'darwinConfigurations' but no builder set. "
+              + "Set 'hostDefaults.builder = inputs.nix-darwin.lib.darwinSystem' or override per-host."
+            else
+              chanPkgs.lib.nixosSystem;
+
+          # Build the config — different top-level args per output type
+          result =
+            if h.output == "darwinConfigurations" then
+              builder
+                {
+                  modules = baseModules;
+                  specialArgs = h.specialArgs;
+                  pkgs = chanPkgs;
+                  inherit (h) system;
+                }
+            else
+              builder {
+                modules = baseModules;
+                specialArgs = h.specialArgs;
+                inherit (h) system;
+              };
+        in
+        { ${h.output}.${name} = result; };
+
+    in
+    {
+      # -----------------------------------------------------------------------
+      # Per-system: expose evaluated channels as a module argument so they can
+      # be used in devShells, packages, etc.
+      #
+      # Usage: perSystem = { fupChannels, ... }: { packages.foo = fupChannels.unstable.callPackage ...; };
+      # -----------------------------------------------------------------------
+      perSystem = { system, ... }: {
+        config._module.args.fupChannels = getChannelsFor system;
+      };
+
+      # -----------------------------------------------------------------------
+      # Flake-level: build host configuration sets
+      # -----------------------------------------------------------------------
+      flake = foldl' recursiveUpdate { }
+        (mapAttrsToList buildOneHost cfg.hosts);
+    };
+}


### PR DESCRIPTION
## What

This PR adds an example under `examples/flake-parts-module/` that demonstrates how FUP's core abstractions — multi-channel management, declarative hosts, overlay propagation, auto-registry — can be expressed as a **composable flake-parts module**.

It is a **proof-of-concept**, not a replacement for `mkFlake`. It shows that the same design patterns that make FUP ergonomic work naturally within flake-parts' module system.

## Features

| FUP concept | Module option |
|---|---|
| `channels.<name>` | `fup.channels.<name>` — declare channels with `input`, `config`, `overlaysBuilder`, `patches` |
| `sharedOverlays` | `fup.sharedOverlays` — overlays applied to every channel |
| `channelsConfig` | `fup.channelsConfig` — default nixpkgs config |
| `hosts` / `hostDefaults` | `fup.hosts` / `fup.hostDefaults` — reverse-DNS naming, builder dispatch (NixOS/darwin) |
| `nix.generateRegistryFromInputs` / `nix.generateNixPathFromInputs` | `fup.autoRegistry` / `fup.autoNixPath` — NixOS module fragments added to each host |
| `self.pkgs` per-system access | `fupChannels` perSystem module argument |

## Key architectural difference from mkFlake

Instead of a monolithic function, this uses flake-parts' option system:
- Channels are evaluated once per (system, channel) pair at the flake level, cached, then injected into perSystem via `_module.args.fupChannels`
- No double-eval of NixOS config to sniff `nixpkgs.config` (the original mkFlake's biggest design debt)
- No `srcs` side-channel injection into nixpkgs
- Hosts read from the same channel cache via `getSystem`

## Files

```
examples/flake-parts-module/
├── README.md
├── fup-module.nix    # The flake-parts module (347 lines)
└── flake.nix         # Example usage with 2 channels, 2 hosts, auto-registry
```

## Try it

```bash
cd examples/flake-parts-module
nix flake show
```